### PR TITLE
Fix nanopb build on git workflow (ci) 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
         run: |
           cmake --version
           python3 --version
-          pip3 install protobuf
+          pip3 install protobuf grpcio-tools
       - name: Configure project
         run: >
           cmake -S. -Bbuild


### PR DESCRIPTION
Error:
    from .proto import nanopb_pb2
    ImportError: attempted relative import with no known parent package