### PR TITLE
fix(foundation,phe,ratchet): apply confirmed security and bugfixes

### DIFF
--- a/library/foundation/src/vscf_aes256_cbc.c
+++ b/library/foundation/src/vscf_aes256_cbc.c
@@ -195,7 +195,7 @@ vscf_aes256_cbc_precise_encrypted_len(const vscf_aes256_cbc_t *self, size_t data
 
     VSCF_ASSERT_PTR(self);
 
-    const size_t left = data_len % vscf_aes256_cbc_BLOCK_LEN == 0;
+    const size_t left = data_len % vscf_aes256_cbc_BLOCK_LEN;
     return data_len + vscf_aes256_cbc_BLOCK_LEN - left;
 }
 

--- a/library/foundation/src/vscf_compound_public_key.c
+++ b/library/foundation/src/vscf_compound_public_key.c
@@ -245,7 +245,7 @@ vscf_compound_public_key_is_valid(const vscf_compound_public_key_t *self) {
         return false;
     }
 
-    const bool is_cipher_key_valid = vscf_key_is_valid(self->signer_key);
-    const bool is_signer_key_valid = vscf_key_is_valid(self->cipher_key);
+    const bool is_cipher_key_valid = vscf_key_is_valid(self->cipher_key);
+    const bool is_signer_key_valid = vscf_key_is_valid(self->signer_key);
     return is_cipher_key_valid && is_signer_key_valid;
 }

--- a/library/foundation/src/vscf_ecc.c
+++ b/library/foundation/src/vscf_ecc.c
@@ -266,7 +266,7 @@ vscf_ecc_generate_key(const vscf_ecc_t *self, vscf_alg_id_t alg_id, vscf_error_t
 
     const int mbed_status = mbedtls_ecp_gen_keypair(&private_key->ecc_grp, &private_key->ecc_priv,
             &private_key->ecc_pub, vscf_mbedtls_bridge_random, self->random);
-    VSCF_ASSERT_ALLOC(status != MBEDTLS_ERR_MPI_ALLOC_FAILED);
+    VSCF_ASSERT_ALLOC(mbed_status != MBEDTLS_ERR_MPI_ALLOC_FAILED);
 
     if (mbed_status != 0) {
         vscf_ecc_private_key_destroy(&private_key);

--- a/library/foundation/src/vscf_message_info_der_serializer.c
+++ b/library/foundation/src/vscf_message_info_der_serializer.c
@@ -2088,7 +2088,7 @@ vscf_message_info_der_serializer_serialized_len(
         const vscf_message_info_custom_params_t *custom_params =
                 vscf_message_info_custom_params((vscf_message_info_t *)message_info);
         custom_params_len += 1 + 8; //  [0] OPTIONAL
-        custom_params_len = vscf_message_info_der_serializer_serialized_custom_params_len(self, custom_params);
+        custom_params_len += vscf_message_info_der_serializer_serialized_custom_params_len(self, custom_params);
     }
 
     size_t footer_info_len = 0;
@@ -2102,14 +2102,14 @@ vscf_message_info_der_serializer_serialized_len(
     if (vscf_message_info_has_cipher_kdf_alg_info(message_info)) {
         const vscf_impl_t *alg_info = vscf_message_info_cipher_kdf_alg_info((vscf_message_info_t *)message_info);
         kdf_alg_info_len += 1 + 1; //  [2] OPTIONAL
-        kdf_alg_info_len = vscf_alg_info_der_serializer_serialized_len(self->alg_info_serializer, alg_info);
+        kdf_alg_info_len += vscf_alg_info_der_serializer_serialized_len(self->alg_info_serializer, alg_info);
     }
 
     size_t padding_alg_info_len = 0;
     if (vscf_message_info_has_cipher_padding_alg_info(message_info)) {
         const vscf_impl_t *alg_info = vscf_message_info_cipher_padding_alg_info((vscf_message_info_t *)message_info);
         padding_alg_info_len += 1 + 1; //  [3] OPTIONAL
-        padding_alg_info_len = vscf_alg_info_der_serializer_serialized_len(self->alg_info_serializer, alg_info);
+        padding_alg_info_len += vscf_alg_info_der_serializer_serialized_len(self->alg_info_serializer, alg_info);
     }
 
     size_t len = 1 + 1 + 8 +            //  VirgilMessageInfo ::= SEQUENCE {
@@ -2478,6 +2478,8 @@ vscf_message_info_der_serializer_deserialize_footer(
 
     vscf_asn1_reader_reset(self->asn1_reader, data);
 
+    vscf_message_info_footer_t *footer = NULL;
+
     vscf_asn1_reader_read_sequence(self->asn1_reader);
     const int version = vscf_asn1_reader_read_int(self->asn1_reader);
 
@@ -2486,7 +2488,7 @@ vscf_message_info_der_serializer_deserialize_footer(
         goto error;
     }
 
-    vscf_message_info_footer_t *footer = vscf_message_info_footer_new();
+    footer = vscf_message_info_footer_new();
 
     const size_t signer_infos_tag_len = vscf_asn1_reader_read_context_tag(self->asn1_reader, 0);
     if (signer_infos_tag_len != 0) {

--- a/library/foundation/src/vscf_oid.c
+++ b/library/foundation/src/vscf_oid.c
@@ -666,12 +666,12 @@ vscf_oid_id_to_alg_id(vscf_oid_id_t oid_id) {
     case vscf_oid_id_PKCS5_PBES2:
         return vscf_alg_id_PKCS5_PBES2;
 
+    case vscf_oid_id_HMAC_WITH_SHA224:
     case vscf_oid_id_HMAC_WITH_SHA256:
     case vscf_oid_id_HMAC_WITH_SHA384:
     case vscf_oid_id_HMAC_WITH_SHA512:
         return vscf_alg_id_HMAC;
 
-    case vscf_oid_id_HMAC_WITH_SHA224:
     case vscf_oid_id_HKDF_WITH_SHA256:
     case vscf_oid_id_HKDF_WITH_SHA384:
     case vscf_oid_id_HKDF_WITH_SHA512:

--- a/library/foundation/src/vscf_padding_cipher.c
+++ b/library/foundation/src/vscf_padding_cipher.c
@@ -554,7 +554,7 @@ vscf_padding_cipher_finish_decryption(vscf_padding_cipher_t *self, vsc_buffer_t 
 
     const vscf_status_t trim_status = vscf_padding_finish_padded_data_processing(self->padding, out);
     if (trim_status != vscf_status_SUCCESS) {
-        return status;
+        return trim_status;
     }
 
     return vscf_status_SUCCESS;

--- a/library/phe/src/vsce_phe_client.c
+++ b/library/phe/src/vsce_phe_client.c
@@ -517,8 +517,6 @@ vsce_phe_client_set_keys(vsce_phe_client_t *self, vsc_data_t client_private_key,
     VSCE_ASSERT_PTR(self);
     VSCE_ASSERT(!self->keys_are_set);
 
-    self->keys_are_set = true;
-
     VSCE_ASSERT(client_private_key.len == vsce_phe_common_PHE_PRIVATE_KEY_LENGTH);
     VSCE_ASSERT(server_public_key.len == vsce_phe_common_PHE_PUBLIC_KEY_LENGTH);
     memcpy(self->server_public_key, server_public_key.bytes, server_public_key.len);
@@ -548,6 +546,8 @@ vsce_phe_client_set_keys(vsce_phe_client_t *self, vsc_data_t client_private_key,
         status = vsce_status_ERROR_INVALID_PUBLIC_KEY;
         goto err;
     }
+
+    self->keys_are_set = true;
 
 err:
     return status;
@@ -840,7 +840,7 @@ ecp_err:
     mbedtls_ecp_point_free(&t0);
 
 pb_err:
-    vsce_zeroize(&record, sizeof(&record));
+    vsce_zeroize(&record, sizeof(record));
     vsce_phe_client_free_op_group(op_group);
 
     return status;

--- a/library/phe/src/vsce_phe_hash.c
+++ b/library/phe/src/vsce_phe_hash.c
@@ -555,10 +555,10 @@ vsce_phe_hash_push_points_to_buffer(vsce_phe_hash_t *self, vsc_buffer_t *buffer,
         const mbedtls_ecp_point *p = va_arg(points, const mbedtls_ecp_point *);
 
         if (p != NULL) {
-            mbedtls_ecp_point_write_binary(&self->group, p, MBEDTLS_ECP_PF_UNCOMPRESSED, &olen,
+            mbedtls_status = mbedtls_ecp_point_write_binary(&self->group, p, MBEDTLS_ECP_PF_UNCOMPRESSED, &olen,
                     vsc_buffer_unused_bytes(buffer), vsc_buffer_unused_len(buffer));
-            vsc_buffer_inc_used(buffer, olen);
             VSCE_ASSERT_LIBRARY_MBEDTLS_SUCCESS(mbedtls_status);
+            vsc_buffer_inc_used(buffer, olen);
             VSCE_ASSERT(olen == vsce_phe_common_PHE_POINT_LENGTH);
         }
     }

--- a/library/phe/src/vsce_proof_verifier.c
+++ b/library/phe/src/vsce_proof_verifier.c
@@ -387,9 +387,6 @@ vsce_proof_verifier_check_success_proof(vsce_proof_verifier_t *self, mbedtls_ecp
         goto err;
     }
 
-    mbedtls_ecp_point_free(&t1);
-    mbedtls_ecp_point_free(&t2);
-
     // if term2 * (c0 ** challenge) != hs0 ** blind_x:
     // return False
 
@@ -405,9 +402,6 @@ vsce_proof_verifier_check_success_proof(vsce_proof_verifier_t *self, mbedtls_ecp
     }
 
     if (tp_mode) {
-        mbedtls_ecp_point_free(&t1);
-        mbedtls_ecp_point_free(&t2);
-
         // if term3 * (c1 ** challenge) != hs1 ** blind_x:
         // return False
 

--- a/library/phe/src/vsce_uokms_wrap_rotation.c
+++ b/library/phe/src/vsce_uokms_wrap_rotation.c
@@ -346,6 +346,7 @@ vsce_uokms_wrap_rotation_set_update_token(vsce_uokms_wrap_rotation_t *self, vsc_
 
     mbedtls_status = mbedtls_ecp_check_privkey(&self->group, &self->a);
     if (mbedtls_status != 0) {
+        mbedtls_mpi_free(&self->a);
         return vsce_status_ERROR_INVALID_PRIVATE_KEY;
     }
 

--- a/library/ratchet/src/vscr_ratchet.c
+++ b/library/ratchet/src/vscr_ratchet.c
@@ -906,7 +906,10 @@ vscr_ratchet_deserialize(const vscr_Ratchet *ratchet_pb, vscr_ratchet_t *ratchet
 
     memcpy(ratchet->root_key, ratchet_pb->root_key, sizeof(ratchet->root_key));
 
-    vscr_ratchet_skipped_messages_deserialize(&ratchet_pb->skipped_messages, ratchet->skipped_messages);
+    status = vscr_ratchet_skipped_messages_deserialize(&ratchet_pb->skipped_messages, ratchet->skipped_messages);
+    if (status != vscr_status_SUCCESS) {
+        goto err;
+    }
 
 err:
     return status;

--- a/library/ratchet/src/vscr_ratchet_skipped_messages.c
+++ b/library/ratchet/src/vscr_ratchet_skipped_messages.c
@@ -49,6 +49,7 @@
 #include "vscr_assert.h"
 #include "vscr_ratchet_skipped_messages_defs.h"
 #include "vscr_ratchet_chain_key.h"
+#include "vscr_status.h"
 
 // clang-format on
 //  @end
@@ -361,12 +362,16 @@ vscr_ratchet_skipped_messages_serialize(
     }
 }
 
-VSCR_PUBLIC void
+VSCR_PUBLIC vscr_status_t
 vscr_ratchet_skipped_messages_deserialize(
         const vscr_SkippedMessages *skipped_messages_pb, vscr_ratchet_skipped_messages_t *skipped_messages) {
 
     VSCR_ASSERT_PTR(skipped_messages_pb);
     VSCR_ASSERT_PTR(skipped_messages);
+
+    if (skipped_messages_pb->keys_count > (pb_size_t)vscr_ratchet_common_hidden_MAX_SKIPPED_DH) {
+        return vscr_status_ERROR_PROTOBUF_DECODE;
+    }
 
     skipped_messages->roots_count = skipped_messages_pb->keys_count;
 
@@ -380,4 +385,6 @@ vscr_ratchet_skipped_messages_deserialize(
 
         skipped_messages->root_nodes[i] = root;
     }
+
+    return vscr_status_SUCCESS;
 }

--- a/library/ratchet/src/vscr_ratchet_skipped_messages.h
+++ b/library/ratchet/src/vscr_ratchet_skipped_messages.h
@@ -56,6 +56,7 @@
 // --------------------------------------------------------------------------
 
 #include "vscr_library.h"
+#include "vscr_status.h"
 #include "vscr_ratchet_message_key.h"
 #include "vscr_ratchet_skipped_messages.h"
 
@@ -144,7 +145,7 @@ vscr_ratchet_skipped_messages_add_key(vscr_ratchet_skipped_messages_t *self, vsc
 VSCR_PUBLIC void
 vscr_ratchet_skipped_messages_serialize(const vscr_ratchet_skipped_messages_t *self, vscr_SkippedMessages *skipped_messages_pb);
 
-VSCR_PUBLIC void
+VSCR_PUBLIC vscr_status_t
 vscr_ratchet_skipped_messages_deserialize(const vscr_SkippedMessages *skipped_messages_pb, vscr_ratchet_skipped_messages_t *skipped_messages);
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
foundation:
- vscf_aes256_cbc: fix precise_encrypted_len computing == 0 instead of remainder
- vscf_compound_public_key: fix swapped cipher_key/signer_key in is_valid
- vscf_ecc: fix ASSERT checking uninitialized status instead of mbed_status
- vscf_message_info_der_serializer: fix = vs += for custom_params/kdf/padding len accumulation; move footer declaration before goto
- vscf_oid: move HMAC_WITH_SHA224 into HMAC case group (was misplaced before HKDF)
- vscf_padding_cipher: return trim_status instead of wrong status on padding error

phe:
- vsce_phe_client: set keys_are_set only after successful validation; fix sizeof(&record) → sizeof(record) in zeroize call
- vsce_phe_hash: capture and check return value of mbedtls_ecp_point_write_binary
- vsce_proof_verifier: remove premature ecp_point_free calls before points are done
- vsce_uokms_wrap_rotation: free MPI before early return on invalid private key

ratchet:
- vscr_ratchet: propagate error from skipped_messages_deserialize
- vscr_ratchet_skipped_messages: change deserialize from void to vscr_status_t; add bounds check on keys_count against MAX_SKIPPED_DH