### PR TITLE
fix(ratchet): address 6 Copilot review comments from PR #180

### DIFF
--- a/codegen/models/project_foundation/class_key_alg_factory.xml
+++ b/codegen/models/project_foundation/class_key_alg_factory.xml
@@ -11,7 +11,7 @@
     <require impl="hybrid key alg" is_optional="1"/>
     <require impl="falcon" is_optional="1"/>
     <require impl="ml kem" is_optional="1"/>
-    <require impl="ml sig" is_optional="1"/>
+    <require impl="ml dsa" is_optional="1"/>
 
     <method name="create from alg id" is_static="1">
         Create a key algorithm based on an identifier.

--- a/codegen/models/project_ratchet/class_ratchet_skipped_messages.xml
+++ b/codegen/models/project_ratchet/class_ratchet_skipped_messages.xml
@@ -51,5 +51,7 @@
     <method name="deserialize" is_static="1">
         <argument name="skipped messages pb" class="vscr_SkippedMessages" library="nanopb"/>
         <argument name="skipped messages" class="self" access="readwrite"/>
+
+        <return enum="status"/>
     </method>
 </class>

--- a/codegen/models/project_ratchet/enum_status.xml
+++ b/codegen/models/project_ratchet/enum_status.xml
@@ -121,6 +121,10 @@
         Myself is included in info.
     </constant>
 
+    <constant name="error kem failed" value="-30">
+        KEM encapsulate or decapsulate operation failed.
+    </constant>
+
     <constant name="error sign failed" value="-31">
         Signing operation failed.
     </constant>

--- a/library/ratchet/include/virgil/crypto/ratchet/vscr_status.h
+++ b/library/ratchet/include/virgil/crypto/ratchet/vscr_status.h
@@ -189,6 +189,10 @@ enum vscr_status_t {
     //
     vscr_status_ERROR_MYSELF_IS_INCLUDED_IN_INFO = -29,
     //
+    //  KEM encapsulate or decapsulate operation failed.
+    //
+    vscr_status_ERROR_KEM_FAILED = -30,
+    //
     //  Signing operation failed.
     //
     vscr_status_ERROR_SIGN_FAILED = -31,

--- a/library/ratchet/protobuf/vscr_RatchetMessage.options
+++ b/library/ratchet/protobuf/vscr_RatchetMessage.options
@@ -1,7 +1,7 @@
 vscr_RegularMessageHeader.public_key max_size:32 fixed_length:true
 
-vscr_RegularMessageHeaderPqcInfo.encapsulated_key type:FT_POINTER
-vscr_RegularMessageHeaderPqcInfo.public_key type:FT_POINTER
+vscr_RegularMessageHeaderPqcInfo.encapsulated_key max_size:1088 type:FT_POINTER
+vscr_RegularMessageHeaderPqcInfo.public_key max_size:1256 type:FT_POINTER
 
 vscr_RegularMessage.header type:FT_POINTER
 vscr_RegularMessage.cipher_text max_size:32975 type:FT_POINTER
@@ -12,7 +12,7 @@ vscr_PrekeyMessage.receiver_identity_key_id max_size:8 fixed_length:true
 vscr_PrekeyMessage.receiver_long_term_key_id max_size:8 fixed_length:true
 vscr_PrekeyMessage.receiver_one_time_key_id max_size:8 fixed_length:true
 
-vscr_PrekeyMessagePqcInfo.encapsulated_key1 type:FT_POINTER
-vscr_PrekeyMessagePqcInfo.encapsulated_key2 type:FT_POINTER
-vscr_PrekeyMessagePqcInfo.encapsulated_key3 type:FT_POINTER
-vscr_PrekeyMessagePqcInfo.decapsulated_keys_signature max_size:809 type:FT_POINTER
+vscr_PrekeyMessagePqcInfo.encapsulated_key1 max_size:1088 type:FT_POINTER
+vscr_PrekeyMessagePqcInfo.encapsulated_key2 max_size:1088 type:FT_POINTER
+vscr_PrekeyMessagePqcInfo.encapsulated_key3 max_size:1088 type:FT_POINTER
+vscr_PrekeyMessagePqcInfo.decapsulated_keys_signature max_size:3309 type:FT_POINTER

--- a/library/ratchet/protobuf/vscr_RatchetSession.options
+++ b/library/ratchet/protobuf/vscr_RatchetSession.options
@@ -4,13 +4,13 @@ vscr_MessageKey.key max_size:32 fixed_length:true
 
 vscr_SenderChain.private_key_first max_size:32 fixed_length:true
 vscr_SenderChain.public_key_first max_size:32 fixed_length:true
-vscr_SenderChain.private_key_second type:FT_POINTER
-vscr_SenderChain.public_key_second type:FT_POINTER
-vscr_SenderChain.encapsulated_key type:FT_POINTER
+vscr_SenderChain.private_key_second max_size:2500 type:FT_POINTER
+vscr_SenderChain.public_key_second max_size:1256 type:FT_POINTER
+vscr_SenderChain.encapsulated_key max_size:1088 type:FT_POINTER
 
 vscr_ReceiverChain.public_key_id max_size:8 fixed_length:true
 vscr_ReceiverChain.public_key_first max_size:32 fixed_length:true
-vscr_ReceiverChain.public_key_second type:FT_POINTER
+vscr_ReceiverChain.public_key_second max_size:1256 type:FT_POINTER
 
 vscr_SkippedMessageKey.public_key_id max_size:8 fixed_length:true
 
@@ -24,10 +24,10 @@ vscr_Session.receiver_identity_key_id max_size:8 fixed_length:true
 vscr_Session.receiver_long_term_key_id max_size:8 fixed_length:true
 vscr_Session.receiver_one_time_key_id max_size:8 fixed_length:true
 
-vscr_SessionPqcInfo.encapsulated_key1 type:FT_POINTER
-vscr_SessionPqcInfo.encapsulated_key2 type:FT_POINTER
-vscr_SessionPqcInfo.encapsulated_key3 type:FT_POINTER
-vscr_SessionPqcInfo.decapsulated_keys_signature max_size:809 type:FT_POINTER
+vscr_SessionPqcInfo.encapsulated_key1 max_size:1088 type:FT_POINTER
+vscr_SessionPqcInfo.encapsulated_key2 max_size:1088 type:FT_POINTER
+vscr_SessionPqcInfo.encapsulated_key3 max_size:1088 type:FT_POINTER
+vscr_SessionPqcInfo.decapsulated_keys_signature max_size:3309 type:FT_POINTER
 
 vscr_ParticipantData.id max_size:32 fixed_length:true
 vscr_ParticipantData.pub_key max_size:32 fixed_length:true

--- a/library/ratchet/src/vscr_ratchet_keys.c
+++ b/library/ratchet/src/vscr_ratchet_keys.c
@@ -425,7 +425,7 @@ vscr_ratchet_keys_create_chain_key_sender(vscr_ratchet_keys_t *self, const vscr_
         vscf_impl_destroy(&kem_alg);
 
         if (f_status != vscf_status_SUCCESS) {
-            status = vscr_status_ERROR_KEY_DESERIALIZATION_FAILED;
+            status = vscr_status_ERROR_KEM_FAILED;
             goto err;
         }
     }
@@ -476,7 +476,7 @@ vscr_ratchet_keys_create_chain_key_receiver(vscr_ratchet_keys_t *self, const vsc
         vscf_impl_destroy(&kem_alg);
 
         if (f_status != vscf_status_SUCCESS) {
-            status = vscr_status_ERROR_KEY_DESERIALIZATION_FAILED;
+            status = vscr_status_ERROR_KEM_FAILED;
             goto err;
         }
     }

--- a/library/ratchet/src/vscr_ratchet_pb_utils.c
+++ b/library/ratchet/src/vscr_ratchet_pb_utils.c
@@ -294,9 +294,16 @@ vscr_ratchet_pb_utils_serialize_public_key(const vscf_impl_t *key, pb_bytes_arra
 
     VSCR_ASSERT_PTR(key);
     VSCR_ASSERT_PTR(pb_buffer_ref);
-    VSCR_ASSERT(vscf_impl_tag(key) == vscf_impl_tag_RAW_PUBLIC_KEY);
 
-    const vscf_raw_public_key_t *raw_key = (const vscf_raw_public_key_t *)key;
+    vscf_error_t error_ctx;
+    vscf_error_reset(&error_ctx);
+
+    vscf_impl_t *key_alg = vscf_key_alg_factory_create_from_key(key, NULL, &error_ctx);
+    VSCR_ASSERT(!vscf_error_has_error(&error_ctx));
+
+    vscf_raw_public_key_t *raw_key = vscf_key_alg_export_public_key(key_alg, key, &error_ctx);
+    VSCR_ASSERT(!vscf_error_has_error(&error_ctx));
+    vscf_impl_destroy(&key_alg);
 
     vscf_key_asn1_serializer_t *serializer = vscf_key_asn1_serializer_new();
     vscf_key_asn1_serializer_setup_defaults(serializer);
@@ -311,6 +318,7 @@ vscr_ratchet_pb_utils_serialize_public_key(const vscf_impl_t *key, pb_bytes_arra
 
     vsc_buffer_destroy(&buf);
     vscf_key_asn1_serializer_destroy(&serializer);
+    vscf_raw_public_key_destroy(&raw_key);
 }
 
 VSCR_PUBLIC vscr_status_t
@@ -356,9 +364,16 @@ vscr_ratchet_pb_utils_serialize_private_key(const vscf_impl_t *key, pb_bytes_arr
 
     VSCR_ASSERT_PTR(key);
     VSCR_ASSERT_PTR(pb_buffer_ref);
-    VSCR_ASSERT(vscf_impl_tag(key) == vscf_impl_tag_RAW_PRIVATE_KEY);
 
-    const vscf_raw_private_key_t *raw_key = (const vscf_raw_private_key_t *)key;
+    vscf_error_t error_ctx;
+    vscf_error_reset(&error_ctx);
+
+    vscf_impl_t *key_alg = vscf_key_alg_factory_create_from_key(key, NULL, &error_ctx);
+    VSCR_ASSERT(!vscf_error_has_error(&error_ctx));
+
+    vscf_raw_private_key_t *raw_key = vscf_key_alg_export_private_key(key_alg, key, &error_ctx);
+    VSCR_ASSERT(!vscf_error_has_error(&error_ctx));
+    vscf_impl_destroy(&key_alg);
 
     vscf_key_asn1_serializer_t *serializer = vscf_key_asn1_serializer_new();
     vscf_key_asn1_serializer_setup_defaults(serializer);
@@ -374,6 +389,7 @@ vscr_ratchet_pb_utils_serialize_private_key(const vscf_impl_t *key, pb_bytes_arr
 
     vsc_buffer_destroy(&buf);
     vscf_key_asn1_serializer_destroy(&serializer);
+    vscf_raw_private_key_destroy(&raw_key);
 }
 
 VSCR_PUBLIC vscr_status_t

--- a/library/ratchet/src/vscr_ratchet_skipped_messages.h
+++ b/library/ratchet/src/vscr_ratchet_skipped_messages.h
@@ -146,7 +146,7 @@ VSCR_PUBLIC void
 vscr_ratchet_skipped_messages_serialize(const vscr_ratchet_skipped_messages_t *self, vscr_SkippedMessages *skipped_messages_pb);
 
 VSCR_PUBLIC vscr_status_t
-vscr_ratchet_skipped_messages_deserialize(const vscr_SkippedMessages *skipped_messages_pb, vscr_ratchet_skipped_messages_t *skipped_messages);
+vscr_ratchet_skipped_messages_deserialize(const vscr_SkippedMessages *skipped_messages_pb, vscr_ratchet_skipped_messages_t *skipped_messages) VSCR_NODISCARD;
 
 // --------------------------------------------------------------------------
 //  Generated section end.

--- a/tests/ratchet/test_ratchet_session_integration.c
+++ b/tests/ratchet/test_ratchet_session_integration.c
@@ -42,6 +42,7 @@
 
 #include "vscr_ratchet_message_defs.h"
 #include "vscr_ratchet_session.h"
+#include "vscf_private_key.h"
 #include "test_utils_ratchet.h"
 
 // --------------------------------------------------------------------------
@@ -241,6 +242,165 @@ test__encrypt_decrypt__randomly_skipped_messages__decrypt_should_succeed(void) {
     vscf_ctr_drbg_destroy(&rng);
 }
 
+void
+test__pqc_ml_dsa_65__encrypt_decrypt_with_restore__should_succeed(void) {
+    vscf_ctr_drbg_t *rng = vscf_ctr_drbg_new();
+    TEST_ASSERT_EQUAL(vscf_status_SUCCESS, vscf_ctr_drbg_setup_defaults(rng));
+
+    vscf_key_provider_t *key_provider = vscf_key_provider_new();
+    vscf_key_provider_use_random(key_provider, vscf_ctr_drbg_impl(rng));
+
+    vscf_impl_t *alice_priv = generate_identity_private_key_ml_dsa(key_provider);
+    vscf_impl_t *alice_pub = vscf_private_key_extract_public_key(alice_priv);
+    vscf_impl_t *bob_priv = generate_identity_private_key_ml_dsa(key_provider);
+    vscf_impl_t *bob_pub = vscf_private_key_extract_public_key(bob_priv);
+    vscf_impl_t *bob_lt_priv = generate_ephemeral_private_key(key_provider, true);
+    vscf_impl_t *bob_lt_pub = vscf_private_key_extract_public_key(bob_lt_priv);
+
+    vsc_buffer_t *alice_id = NULL, *bob_id = NULL, *bob_lt_id = NULL;
+    generate_random_data_of_size(rng, &alice_id, 8);
+    generate_random_data_of_size(rng, &bob_id, 8);
+    generate_random_data_of_size(rng, &bob_lt_id, 8);
+    vsc_buffer_t *no_ot_id = vsc_buffer_new_with_capacity(0);
+
+    vscr_ratchet_session_t *session_alice = vscr_ratchet_session_new();
+    vscr_ratchet_session_t *session_bob = vscr_ratchet_session_new();
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS, vscr_ratchet_session_setup_defaults(session_alice));
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS, vscr_ratchet_session_setup_defaults(session_bob));
+
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS,
+            vscr_ratchet_session_initiate(session_alice, alice_priv, vsc_buffer_data(alice_id), bob_pub,
+                    vsc_buffer_data(bob_id), bob_lt_pub, vsc_buffer_data(bob_lt_id), NULL, vsc_buffer_data(no_ot_id)));
+
+    vscr_error_t error;
+    vscr_error_reset(&error);
+    vsc_buffer_t *text1 = NULL;
+    generate_random_data(rng, &text1);
+
+    vscr_ratchet_message_t *msg1 = vscr_ratchet_session_encrypt(session_alice, vsc_buffer_data(text1), &error);
+    TEST_ASSERT_FALSE(vscr_error_has_error(&error));
+    TEST_ASSERT_EQUAL(vscr_msg_type_PREKEY, vscr_ratchet_message_get_type(msg1));
+
+    // Serialize Alice after encrypt — exercises serialize_public_key on imported ML-KEM key
+    restore_session(rng, &session_alice);
+
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS,
+            vscr_ratchet_session_respond(session_bob, alice_pub, bob_priv, bob_lt_priv, NULL, msg1));
+
+    restore_session(rng, &session_bob);
+
+    size_t len1 = vscr_ratchet_session_decrypt_len(session_bob, msg1);
+    vsc_buffer_t *plain1 = vsc_buffer_new_with_capacity(len1);
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS, vscr_ratchet_session_decrypt(session_bob, msg1, plain1));
+    TEST_ASSERT_EQUAL_DATA_AND_BUFFER(vsc_buffer_data(text1), plain1);
+
+    restore_session(rng, &session_alice);
+    restore_session(rng, &session_bob);
+
+    // Bob replies, Alice decrypts through another restore cycle
+    vsc_buffer_t *text2 = NULL;
+    generate_random_data(rng, &text2);
+    vscr_ratchet_message_t *msg2 = vscr_ratchet_session_encrypt(session_bob, vsc_buffer_data(text2), &error);
+    TEST_ASSERT_FALSE(vscr_error_has_error(&error));
+    TEST_ASSERT_EQUAL(vscr_msg_type_REGULAR, vscr_ratchet_message_get_type(msg2));
+
+    restore_session(rng, &session_alice);
+
+    size_t len2 = vscr_ratchet_session_decrypt_len(session_alice, msg2);
+    vsc_buffer_t *plain2 = vsc_buffer_new_with_capacity(len2);
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS, vscr_ratchet_session_decrypt(session_alice, msg2, plain2));
+    TEST_ASSERT_EQUAL_DATA_AND_BUFFER(vsc_buffer_data(text2), plain2);
+
+    vscr_ratchet_message_destroy(&msg1);
+    vscr_ratchet_message_destroy(&msg2);
+    vsc_buffer_destroy(&text1);
+    vsc_buffer_destroy(&text2);
+    vsc_buffer_destroy(&plain1);
+    vsc_buffer_destroy(&plain2);
+    vscf_impl_destroy(&alice_priv);
+    vscf_impl_destroy(&alice_pub);
+    vscf_impl_destroy(&bob_priv);
+    vscf_impl_destroy(&bob_pub);
+    vscf_impl_destroy(&bob_lt_priv);
+    vscf_impl_destroy(&bob_lt_pub);
+    vsc_buffer_destroy(&alice_id);
+    vsc_buffer_destroy(&bob_id);
+    vsc_buffer_destroy(&bob_lt_id);
+    vsc_buffer_destroy(&no_ot_id);
+    vscr_ratchet_session_destroy(&session_alice);
+    vscr_ratchet_session_destroy(&session_bob);
+    vscf_key_provider_destroy(&key_provider);
+    vscf_ctr_drbg_destroy(&rng);
+}
+
+void
+test__pqc_ml_dsa_65__100_messages_with_restore__should_succeed(void) {
+    vscf_ctr_drbg_t *rng = vscf_ctr_drbg_new();
+    TEST_ASSERT_EQUAL(vscf_status_SUCCESS, vscf_ctr_drbg_setup_defaults(rng));
+
+    vscf_key_provider_t *key_provider = vscf_key_provider_new();
+    vscf_key_provider_use_random(key_provider, vscf_ctr_drbg_impl(rng));
+
+    vscf_impl_t *alice_priv = generate_identity_private_key_ml_dsa(key_provider);
+    vscf_impl_t *alice_pub = vscf_private_key_extract_public_key(alice_priv);
+    vscf_impl_t *bob_priv = generate_identity_private_key_ml_dsa(key_provider);
+    vscf_impl_t *bob_pub = vscf_private_key_extract_public_key(bob_priv);
+    vscf_impl_t *bob_lt_priv = generate_ephemeral_private_key(key_provider, true);
+    vscf_impl_t *bob_lt_pub = vscf_private_key_extract_public_key(bob_lt_priv);
+
+    vsc_buffer_t *alice_id = NULL, *bob_id = NULL, *bob_lt_id = NULL;
+    generate_random_data_of_size(rng, &alice_id, 8);
+    generate_random_data_of_size(rng, &bob_id, 8);
+    generate_random_data_of_size(rng, &bob_lt_id, 8);
+    vsc_buffer_t *no_ot_id = vsc_buffer_new_with_capacity(0);
+
+    vscr_ratchet_session_t *session_alice = vscr_ratchet_session_new();
+    vscr_ratchet_session_t *session_bob = vscr_ratchet_session_new();
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS, vscr_ratchet_session_setup_defaults(session_alice));
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS, vscr_ratchet_session_setup_defaults(session_bob));
+
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS,
+            vscr_ratchet_session_initiate(session_alice, alice_priv, vsc_buffer_data(alice_id), bob_pub,
+                    vsc_buffer_data(bob_id), bob_lt_pub, vsc_buffer_data(bob_lt_id), NULL, vsc_buffer_data(no_ot_id)));
+
+    vscr_error_t error;
+    vscr_error_reset(&error);
+    vsc_buffer_t *init_text = NULL;
+    generate_random_data(rng, &init_text);
+
+    vscr_ratchet_message_t *init_msg = vscr_ratchet_session_encrypt(session_alice, vsc_buffer_data(init_text), &error);
+    TEST_ASSERT_FALSE(vscr_error_has_error(&error));
+
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS,
+            vscr_ratchet_session_respond(session_bob, alice_pub, bob_priv, bob_lt_priv, NULL, init_msg));
+
+    size_t init_len = vscr_ratchet_session_decrypt_len(session_bob, init_msg);
+    vsc_buffer_t *init_plain = vsc_buffer_new_with_capacity(init_len);
+    TEST_ASSERT_EQUAL(vscr_status_SUCCESS, vscr_ratchet_session_decrypt(session_bob, init_msg, init_plain));
+    TEST_ASSERT_EQUAL_DATA_AND_BUFFER(vsc_buffer_data(init_text), init_plain);
+
+    vscr_ratchet_message_destroy(&init_msg);
+    vsc_buffer_destroy(&init_text);
+    vsc_buffer_destroy(&init_plain);
+
+    encrypt_decrypt__100_plain_texts_random_order_with_producers(rng, &session_alice, &session_bob, true);
+
+    vscf_impl_destroy(&alice_priv);
+    vscf_impl_destroy(&alice_pub);
+    vscf_impl_destroy(&bob_priv);
+    vscf_impl_destroy(&bob_pub);
+    vscf_impl_destroy(&bob_lt_priv);
+    vscf_impl_destroy(&bob_lt_pub);
+    vsc_buffer_destroy(&alice_id);
+    vsc_buffer_destroy(&bob_id);
+    vsc_buffer_destroy(&bob_lt_id);
+    vsc_buffer_destroy(&no_ot_id);
+    vscr_ratchet_session_destroy(&session_alice);
+    vscr_ratchet_session_destroy(&session_bob);
+    vscf_key_provider_destroy(&key_provider);
+    vscf_ctr_drbg_destroy(&rng);
+}
+
 #endif // TEST_DEPENDENCIES_AVAILABLE
 
 
@@ -257,6 +417,8 @@ main(void) {
     RUN_TEST(test__encrypt_decrypt__100_plain_texts_random_order__decrypted_should_match);
     RUN_TEST(test__encrypt_decrypt__1_out_of_order_msg__decrypted_should_match);
     RUN_TEST(test__encrypt_decrypt__randomly_skipped_messages__decrypt_should_succeed);
+    RUN_TEST(test__pqc_ml_dsa_65__encrypt_decrypt_with_restore__should_succeed);
+    RUN_TEST(test__pqc_ml_dsa_65__100_messages_with_restore__should_succeed);
 #else
     RUN_TEST(test__nothing__feature_disabled__must_be_ignored);
 #endif

--- a/tests/ratchet/test_utils_ratchet.c
+++ b/tests/ratchet/test_utils_ratchet.c
@@ -274,6 +274,16 @@ generate_identity_private_key(vscf_key_provider_t *key_provider, bool enable_pqc
 }
 
 vscf_impl_t *
+generate_identity_private_key_ml_dsa(vscf_key_provider_t *key_provider) {
+    vscf_error_t error_ctx;
+    vscf_error_reset(&error_ctx);
+    vscf_impl_t *private_key = vscf_key_provider_generate_compound_hybrid_private_key(key_provider,
+            vscf_alg_id_CURVE25519, vscf_alg_id_ML_KEM_768, vscf_alg_id_ED25519, vscf_alg_id_ML_DSA_65, &error_ctx);
+    TEST_ASSERT_EQUAL(vscf_status_SUCCESS, error_ctx.status);
+    return private_key;
+}
+
+vscf_impl_t *
 generate_ephemeral_private_key(vscf_key_provider_t *key_provider, bool enable_pqc) {
 
     vscf_impl_t *private_key;

--- a/tests/ratchet/test_utils_ratchet.h
+++ b/tests/ratchet/test_utils_ratchet.h
@@ -52,12 +52,15 @@ size_t generate_number(vscf_ctr_drbg_t *rng, size_t min, size_t max);
 double generate_prob(vscf_ctr_drbg_t *rng);
 size_t generate_size(vscf_ctr_drbg_t *rng);
 void generate_random_data(vscf_ctr_drbg_t *rng, vsc_buffer_t **buffer);
+void generate_random_data_of_size(vscf_ctr_drbg_t *rng, vsc_buffer_t **buffer, size_t size);
 void generate_permutation(vscf_ctr_drbg_t *rng, size_t n, size_t *buffer);
 void generate_PKCS8_ed_keypair(vscf_ctr_drbg_t *rng, vsc_buffer_t **priv, vsc_buffer_t **pub);
 void generate_PKCS8_curve_keypair(vscf_ctr_drbg_t *rng, vsc_buffer_t **priv, vsc_buffer_t **pub);
 void generate_random_participant_id(vscf_ctr_drbg_t *rng, vsc_buffer_t **id);
 vscf_impl_t *
 generate_identity_private_key(vscf_key_provider_t *key_provider, bool enable_pqc);
+vscf_impl_t *
+generate_identity_private_key_ml_dsa(vscf_key_provider_t *key_provider);
 vscf_impl_t *
 generate_ephemeral_private_key(vscf_key_provider_t *key_provider, bool enable_pqc);
 void

--- a/wrappers/java/ratchet/src/main/java/com/virgilsecurity/crypto/ratchet/RatchetException.java
+++ b/wrappers/java/ratchet/src/main/java/com/virgilsecurity/crypto/ratchet/RatchetException.java
@@ -98,6 +98,8 @@ public class RatchetException extends RuntimeException {
 
     public static final int ERROR_MYSELF_IS_INCLUDED_IN_INFO = -29;
 
+    public static final int ERROR_KEM_FAILED = -30;
+
     public static final int ERROR_SIGN_FAILED = -31;
 
     public static final int ERROR_DECAPS_SIGNATURE_INVALID = -32;
@@ -175,6 +177,8 @@ public class RatchetException extends RuntimeException {
             return "Simultaneous group user operation.";
         case ERROR_MYSELF_IS_INCLUDED_IN_INFO:
             return "Myself is included in info.";
+        case ERROR_KEM_FAILED:
+            return "KEM encapsulate or decapsulate operation failed.";
         case ERROR_SIGN_FAILED:
             return "Signing operation failed.";
         case ERROR_DECAPS_SIGNATURE_INVALID:

--- a/wrappers/swift/VirgilCrypto/VirgilCryptoRatchet/RatchetError.swift
+++ b/wrappers/swift/VirgilCrypto/VirgilCryptoRatchet/RatchetError.swift
@@ -125,6 +125,9 @@ import VSCRatchet
     /// Myself is included in info.
     case errorMyselfIsIncludedInInfo = -29
 
+    /// KEM encapsulate or decapsulate operation failed.
+    case errorKemFailed = -30
+
     /// Signing operation failed.
     case errorSignFailed = -31
 

--- a/wrappers/wasm/ratchet/src/RatchetError.js
+++ b/wrappers/wasm/ratchet/src/RatchetError.js
@@ -164,6 +164,10 @@ const initRatchetError = (Module, modules) => {
                 throw new RatchetError("Myself is included in info.");
             }
 
+            if (statusCode == -30) {
+                throw new RatchetError("KEM encapsulate or decapsulate operation failed.");
+            }
+
             if (statusCode == -31) {
                 throw new RatchetError("Signing operation failed.");
             }


### PR DESCRIPTION
## Summary

Fixes all 6 issues raised in the Copilot review of PR #180, plus one additional correctness bug discovered during planning, plus ML-DSA-65 integration tests that cover the fixed paths.

- **codegen**: `class_key_alg_factory.xml` had `<require impl="ml sig">` — should be `<require impl="ml dsa">`. Name mismatch would silently drop ML-DSA support on next codegen run.
- **ratchet pb_utils**: `serialize_public_key` and `serialize_private_key` asserted `impl_tag == RAW_PUBLIC/PRIVATE_KEY` then cast directly, but callers pass imported ML-KEM keys (tag = `ML_KEM`). Fixed by exporting to raw via `vscf_key_alg_factory_create_from_key` + `vscf_key_alg_export_public/private_key` before ASN.1 serialization.
- **ratchet status**: KEM encapsulate/decapsulate failures were mapped to `ERROR_KEY_DESERIALIZATION_FAILED` (wrong semantics). Added `ERROR_KEM_FAILED = -30` to distinguish KEM op failures from format errors.
- **nanopb options**: `max_size` was missing on all `FT_POINTER` PQC byte fields in `vscr_RatchetMessage.options` and `vscr_RatchetSession.options` — unbounded nanopb allocation on decode is a DoS risk. Restored conservative upper bounds sized to the max of supported algorithms.
- **correctness**: `decapsulated_keys_signature` was bounded at `max_size:809` (Falcon only). The ratchet signer is algorithm-agnostic and can be ML-DSA-65 (3309 bytes). Fixed to `max_size:3309`.
- **ML-DSA-65 tests**: Two new integration tests use ML-DSA-65 compound-hybrid identity keys with `should_restore=true` at each step, covering the serialize/deserialize path that previously triggered the assert bug.

## Key size reference

| Field | Value | Notes |
|---|---|---|
| ML-KEM-768 ciphertext | 1088 B | raw bytes |
| ML-KEM-768 public key DER | ≤ 1256 B | PKCS#8 overhead |
| ML-KEM-768 private key DER | ≤ 2500 B | PKCS#8 overhead |
| ML-DSA-65 signature | ≤ 3309 B | covers Falcon (809 B) too |

## Test plan

- [ ] `test_ratchet_session_integration` — all 7 tests pass (5 existing + 2 new ML-DSA-65)
- [ ] `test__pqc_ml_dsa_65__encrypt_decrypt_with_restore__should_succeed` — exercises serialize_public_key fix on imported ML-KEM key + 3309-byte signature bound
- [ ] `test__pqc_ml_dsa_65__100_messages_with_restore__should_succeed` — full 100-message randomized exchange with producers and restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)