### PR TITLE
refactor(codegen): extract helpers and annotate all branches for maintainability

### DIFF
--- a/tools/codegen/common_bootstrap.py
+++ b/tools/codegen/common_bootstrap.py
@@ -995,68 +995,128 @@ def _create_file_skeleton(root: ET.Element, is_header: bool, *, license_text: st
     return "\n".join(lines)
 
 
+def _merge_header_includes(
+    root: "ET.Element",
+    merged: str,
+    repo_root: "Path",
+    project: str,
+    old_includes: list[str],
+) -> str:
+    """Merge all include sources into a single ``@generated_header_includes`` section.
+
+    Four sources are combined in priority order (later sources fill gaps, never override):
+
+    1. *old_includes* — includes extracted from the legacy first ``@end`` block of an
+       existing file.  These come first so hand-maintained ordering is preserved.
+    2. *existing_section_includes* — includes already present in the current
+       ``@generated_header_includes`` section, after filtering out stale/invalid entries.
+    3. *renderer_pub_includes* — same-project public includes emitted by the IR-driven
+       renderer (``c_include`` children of *root* with ``scope="public"``).
+    4. *sys_lines* — system ``<...>`` includes from the renderer's ``generate_header_includes_block``.
+
+    WHY cross-project bare includes are filtered from *existing_section_includes*:
+    includes such as ``"vsc_data.h"`` inside a ``vscf_`` header break CGo ``CFLAGS``
+    (which cannot handle bare cross-project paths without the right ``-I`` flags) and
+    are already provided through framework-conditional user-area blocks.
+
+    WHY *_known_bare* is built from ``library/<project>/``:
+    after a broken codegen run that injected wrong-prefix includes, the additive merge
+    would preserve those stale entries on the next run.  Checking against the committed
+    header files breaks this cycle — a bare include that does not exist in the library
+    tree is a codegen artifact, not a real dependency.
+
+    WHY ``self_prefix`` filters *renderer_pub_includes*:
+    renderer ``c_include`` children can reference headers from other projects (cross-project
+    deps).  Those are emitted through user-area blocks and must not be duplicated here.
+
+    Returns the updated *merged* text with the ``@generated_header_includes`` section
+    replaced (or inserted before ``#ifdef __cplusplus``).
+    """
+    include_block = generate_header_includes_block(root)
+    self_include = root.attrib.get("c_include_file", "")
+    self_prefix = self_include.split("_")[0] + "_" if "_" in self_include else ""
+
+    renderer_pub_includes = [
+        render_include(c) for c in root
+        if c.tag == "c_include"
+        and c.attrib.get("scope") == "public"
+        and c.attrib.get("is_system") != "1"
+        and c.attrib.get("file") != self_include
+        and (not self_prefix or c.attrib.get("file", "").startswith(self_prefix))
+    ]
+
+    lib_dir = repo_root / "library" / project
+    _known_bare: set[str] | None = None
+    if lib_dir.is_dir():
+        _known_bare = {p.name for p in lib_dir.rglob("*.h")}
+
+    existing_section_includes: list[str] = []
+    if GENERATED_HEADER_INCLUDES_START in merged:
+        try:
+            sec_start = merged.index(GENERATED_HEADER_INCLUDES_START)
+            sec_end = merged.index(GENERATED_END, sec_start)
+            for ln in merged[sec_start:sec_end].splitlines():
+                stripped = ln.strip()
+                if not stripped.startswith("#include "):
+                    continue
+                if self_prefix and stripped.startswith('#include "'):
+                    fname = stripped[len('#include "'):-1]
+                    if not fname.startswith(self_prefix):
+                        continue
+                    if _known_bare is not None and fname not in _known_bare:
+                        continue
+                existing_section_includes.append(stripped)
+        except ValueError:
+            pass
+
+    sys_lines: list[str] = []
+    if include_block:
+        for ln in include_block.splitlines():
+            if ln.strip().startswith("#include "):
+                sys_lines.append(ln.strip())
+
+    seen: set[str] = set()
+    combined: list[str] = []
+    for inc in (*old_includes, *existing_section_includes, *renderer_pub_includes, *sys_lines):
+        if inc not in seen:
+            combined.append(inc)
+            seen.add(inc)
+
+    if combined:
+        proj = [x for x in combined if x.startswith('#include "')]
+        sys = [x for x in combined if x.startswith("#include <")]
+        out_lines = _generated_block_header(GENERATED_HEADER_INCLUDES_START, "Generated header includes start.")
+        if proj:
+            out_lines.extend(proj)
+            if sys:
+                out_lines.append("")
+        if sys:
+            out_lines.extend(sys)
+        out_lines.append("")
+        out_lines.extend(_generated_block_footer())
+        include_block = "\n".join(out_lines) + "\n"
+
+    if combined or include_block:
+        merged = merge_or_insert_tagged_section(
+            merged,
+            include_block,
+            start_marker=GENERATED_HEADER_INCLUDES_START,
+            anchor_before="#ifdef __cplusplus",
+        )
+    return merged
+
+
 def render_one(xml_path: Path, repo_root: Path, codegen_root: Path, out_root: Path, *, project: str = "common", license_text: str = "") -> list[Path]:
-    """Render one codegen XML descriptor to disk and return the paths that were written.
+    """Render one codegen XML descriptor to disk; return paths written (header and/or source).
 
-    Reads the XML descriptor at *xml_path* (or generates it on the fly via a direct
-    renderer), then creates or updates the header and/or source file it describes.
-
-    Parameters
-    ----------
-    xml_path:
-        Path to the codegen XML descriptor for the entity being rendered.  The descriptor
-        declares ``header_file`` / ``source_file`` attributes that name the output paths
-        relative to *codegen_root*.
-    repo_root:
-        Root of the repository checkout.  Used to locate ``direct_c_renderers`` and the
-        ``library/<project>/`` tree for stale-include detection.
-    codegen_root:
-        Directory where codegen XML descriptors live (``<repo_root>/codegen/``).  Output
-        file paths from the descriptor are resolved relative to this directory.
-    out_root:
-        Root under which generated files are written.  In ``--apply`` mode this equals
-        *repo_root*; otherwise it is a temporary build directory.
-    project:
-        Project name (e.g. ``"foundation"``).  Used to look up a direct renderer and to
-        locate the project's library header tree for include validation.
-    license_text:
-        Full license text to stamp into the ``@license`` block of each file.
-
-    Returns
-    -------
-    list[Path]
-        Absolute paths of every file that was written (typically one header and/or one
-        source file, but possibly zero if the descriptor has no ``header_file`` /
-        ``source_file`` attributes).
-
-    Two main rendering paths
-    ------------------------
-    New file:
-        If the output path does not yet exist, ``_create_file_skeleton`` builds a fresh
-        file with the standard include guards / license block and an empty ``@generated``
-        section.  The generated content is then merged into that skeleton.
-    Existing file (additive merge):
-        The existing file is read and its ``@generated`` section is replaced with freshly
-        generated content.  Code written by humans between ``@end`` / ``@tag`` block
-        markers is preserved unchanged — the renderer is authoritative only for the
-        ``@generated`` region.
-
-    Key invariants
-    --------------
-    * The renderer is authoritative for *adding* new content to the ``@generated`` section;
-      it never removes hand-written code from user-owned sections.
-    * Cross-project bare includes (e.g. ``"vsc_data.h"`` inside a ``vscf_`` header) are
-      dropped from the ``@generated_header_includes`` section because they break CGo
-      ``CFLAGS`` and are already provided through framework-conditional user-area blocks.
-
-    WHY comments (see inline below)
-    --------------------------------
-    * WHY ``direct_c_renderers`` is checked first — some IR entities have a Python-driven
-      renderer that synthesises the XML programmatically rather than reading an XML file.
-    * WHY additive merge — user code between ``@end`` / ``@tag`` blocks must survive every
-      regeneration cycle without manual intervention.
-    * WHY ``self_prefix`` filter on ``renderer_pub_includes`` — keeps only same-project
-      headers so cross-project headers (already handled separately) are not duplicated.
+    Looks up a direct Python renderer first (for synthetic entities with no static XML file),
+    then falls back to parsing xml_path. For each output file declared in the descriptor:
+    - New file: build a skeleton (include guards + license block + empty @generated section).
+    - Existing file: replace @generated section; preserve user code in @tag/@end blocks (additive merge).
+    For headers, delegates include merging to :func:`_merge_header_includes` which combines four
+    sources (legacy block, existing @generated_header_includes section, renderer c_include elements,
+    system includes) with cross-project filtering and stale-artifact removal — see its docstring.
+    Returns [] if the descriptor declares no header_file or source_file attributes.
     """
     # WHY direct_c_renderers is checked first: some entities (e.g. umbrella modules or
     # synthetic shims) have no static XML descriptor — their IR is built entirely in Python.
@@ -1068,6 +1128,8 @@ def render_one(xml_path: Path, repo_root: Path, codegen_root: Path, out_root: Pa
     else:
         root = ET.parse(xml_path).getroot()
     written = []
+    # Two passes over the same root element: first the public header, then the source file.
+    # Not every descriptor declares both; missing attributes are silently skipped.
     for attr, is_header in [("header_file", True), ("source_file", False)]:
         rel = root.attrib.get(attr)
         if not rel:
@@ -1081,123 +1143,8 @@ def render_one(xml_path: Path, repo_root: Path, codegen_root: Path, out_root: Pa
         generated = generate_block(root, is_header)
         merged = merge_generated_section(existing, generated)
         if is_header:
-            # Extract existing includes from the legacy first @end block
-            # and merge them with codegen-produced system includes into a
-            # single @generated_header_includes section.
             merged, old_includes = _extract_old_header_includes(merged)
-            include_block = generate_header_includes_block(root)
-            # Build combined block: user-area legacy includes + existing section includes
-            # + renderer includes + system includes.
-            # The renderer is authoritative for ADDING new includes.  Existing section includes
-            # are preserved additively EXCEPT for cross-project bare includes (e.g. "vsc_data.h"
-            # in a vscf_ header) which break CGo CFLAGS and are already covered by the
-            # framework-conditional user-area blocks.
-            self_include = root.attrib.get("c_include_file", "")
-            self_prefix = self_include.split("_")[0] + "_" if "_" in self_include else ""
-            # WHY self_prefix filter on renderer_pub_includes: the renderer's ``c_include``
-            # children can reference headers from other projects (cross-project deps).
-            # Those cross-project headers must NOT be added to the renderer list because
-            # they are already emitted through framework-conditional user-area blocks and
-            # including them here would duplicate the ``#include`` directives — and,
-            # critically, break CGo ``CFLAGS`` which cannot handle bare cross-project
-            # paths without the right ``-I`` flags.  Filtering to ``self_prefix`` keeps
-            # only same-project headers where the include path is guaranteed to be valid.
-            renderer_pub_includes = [
-                render_include(c) for c in root
-                if c.tag == "c_include"
-                and c.attrib.get("scope") == "public"
-                and c.attrib.get("is_system") != "1"
-                and c.attrib.get("file") != self_include
-                and (not self_prefix or c.attrib.get("file", "").startswith(self_prefix))
-            ]
-            # Build a set of bare filenames that exist in this project's library tree so we
-            # can drop stale same-prefix includes that were injected by a prior broken run.
-            #
-            # WHAT "stale same-prefix includes" are: if a previous codegen run had the
-            # wrong-prefix bug it would have written e.g. `#include "vscr_impl.h"` into
-            # ratchet headers.  The next correct run would see vscr_impl.h in
-            # existing_section_includes and preserve it (additive merge).  _known_bare
-            # breaks this cycle by checking that the include file actually exists in the
-            # project's committed library headers.
-            #
-            # WHY library/<project>/ is the right source of truth: these are the committed
-            # header files.  If a bare include doesn't appear here it was a codegen artifact,
-            # not a real dependency, and should be discarded.
-            #
-            # What _known_bare does NOT catch: includes for files that exist in the library
-            # tree but are wrong for other reasons (e.g. correct filename, wrong project
-            # prefix — that case is handled by the cross-project filter above).
-            # _known_bare is purely an existence guard.
-            lib_dir = repo_root / "library" / project
-            _known_bare: set[str] | None = None
-            if lib_dir.is_dir():
-                _known_bare = {p.name for p in lib_dir.rglob("*.h")}
-            existing_section_includes: list[str] = []
-            if GENERATED_HEADER_INCLUDES_START in merged:
-                try:
-                    sec_start = merged.index(GENERATED_HEADER_INCLUDES_START)
-                    sec_end = merged.index(GENERATED_END, sec_start)
-                    for ln in merged[sec_start:sec_end].splitlines():
-                        stripped = ln.strip()
-                        if not stripped.startswith("#include "):
-                            continue
-                        # Drop cross-project bare includes: they break CGo and are in user area.
-                        if self_prefix and stripped.startswith('#include "'):
-                            fname = stripped[len('#include "'):-1]
-                            if not fname.startswith(self_prefix):
-                                continue
-                            # This file doesn't exist in the project's library tree — likely a stale
-                            # artifact from a prior broken codegen run. Drop it so the correct include
-                            # from the renderer takes its place.
-                            if _known_bare is not None and fname not in _known_bare:
-                                continue
-                        existing_section_includes.append(stripped)
-                except ValueError:
-                    pass
-            sys_lines: list[str] = []
-            if include_block:
-                for ln in include_block.splitlines():
-                    if ln.strip().startswith("#include "):
-                        sys_lines.append(ln.strip())
-            seen: set[str] = set()
-            combined: list[str] = []
-            for inc in old_includes:
-                if inc not in seen:
-                    combined.append(inc)
-                    seen.add(inc)
-            for inc in existing_section_includes:
-                if inc not in seen:
-                    combined.append(inc)
-                    seen.add(inc)
-            for inc in renderer_pub_includes:
-                if inc not in seen:
-                    combined.append(inc)
-                    seen.add(inc)
-            for inc in sys_lines:
-                if inc not in seen:
-                    combined.append(inc)
-                    seen.add(inc)
-            if combined:
-                # Separate project ("...") and system (<...>) includes
-                proj = [x for x in combined if x.startswith('#include "')]
-                sys = [x for x in combined if x.startswith("#include <")]
-                out_lines = _generated_block_header(GENERATED_HEADER_INCLUDES_START, "Generated header includes start.")
-                if proj:
-                    out_lines.extend(proj)
-                    if sys:
-                        out_lines.append("")
-                if sys:
-                    out_lines.extend(sys)
-                out_lines.append("")
-                out_lines.extend(_generated_block_footer())
-                include_block = "\n".join(out_lines) + "\n"
-            if combined or include_block:
-                merged = merge_or_insert_tagged_section(
-                    merged,
-                    include_block,
-                    start_marker=GENERATED_HEADER_INCLUDES_START,
-                    anchor_before="#ifdef __cplusplus",
-                )
+            merged = _merge_header_includes(root, merged, repo_root, project, old_includes)
         out_path = out_root / target.relative_to(repo_root)
         ensure_parent(out_path)
         out_path.write_text(merged)

--- a/tools/codegen/project_c_backend.py
+++ b/tools/codegen/project_c_backend.py
@@ -6960,6 +6960,122 @@ def comment_text(desc: str) -> str:
 
 
 
+def _interface_argument_element(
+    parent: ET.Element,
+    attrs: dict,
+    arg_name: str,
+    project_ir: IRProject | None,
+) -> ET.Element:
+    """Build a ``c_argument`` element for an interface-typed IR argument.
+
+    An interface-typed argument accepts *any* implementation of the named interface,
+    so it maps to a ``{prefix}_impl_t *`` pointer.
+
+    WHY fallback_projects loop: when the interface is declared in a *different* project
+    (e.g. a ``common`` interface referenced from ``foundation``), the ``impl_t`` type must
+    carry that dependency's prefix, not the current project's prefix.  ``fallback_projects``
+    carries the loaded upstream project IRs; scanning it finds the right prefix instead of
+    hard-coding the cross-project name.
+
+    WHY ``disown`` produces a ``_ref`` suffix with double-pointer (``reference``) access:
+    the ``disown`` convention signals transfer-of-ownership — the callee takes exclusive
+    ownership and NULLs the caller's pointer.  C represents this as ``T **``, and the
+    ``_ref`` suffix makes the intent visible at the call site.
+    """
+    arg_project = attrs.get("project")
+    if arg_project and project_ir is not None:
+        prefix = project_ir.prefix
+        for fp in (project_ir.fallback_projects or []):
+            if fp.name == arg_project:
+                prefix = fp.prefix
+                break
+    else:
+        prefix = project_ir.prefix if project_ir is not None else "vscf"
+    type_name = f"{prefix}_impl_t"
+    extra: dict[str, str] = {}
+    effective_access = attrs.get("access", "readonly")
+    if effective_access == "readonly":
+        extra["is_const_type"] = "1"
+    if effective_access == "disown":
+        return text_element(parent, "c_argument", name=f"{arg_name}_ref", accessed_by="reference", type=type_name, type_is="class", **extra)
+    return text_element(parent, "c_argument", name=arg_name, accessed_by="pointer", type=type_name, type_is="class", **extra)
+
+
+def _class_argument_element(
+    parent: ET.Element,
+    attrs: dict,
+    arg_name: str,
+    owner_class: str,
+    project_ir: IRProject | None,
+) -> ET.Element:
+    """Build a ``c_argument`` element for a class-typed IR argument.
+
+    Determines the C type name and ``accessed_by`` mode (``value``, ``pointer``,
+    ``reference``) from the argument's access mode, value-type flag, and array markers.
+
+    Precedence for ``accessed_by`` (first matching rule wins):
+
+    1. ``class == "self"`` + ``passed_by == "reference"`` → ``reference`` (double-pointer self).
+    2. ``class == "self"`` → ``pointer`` unless the owning class is a value type (→ ``value``).
+    3. ``library`` non-self → pointer by default; ``is_reference="0"`` → value;
+       array ``given`` + ``is_reference`` → reference.
+    4. Non-self IR class → pointer unless the target class is a value type (→ ``value``).
+    5. Array marker (``_array``/``array`` == ``"given"``) overrides the above: ``pointer``
+       (or ``reference`` when ``is_reference`` is also set).
+
+    WHY ``disown`` produces a ``_ref`` suffix with double-pointer (``reference``) access:
+    same transfer-of-ownership convention as for interface-typed args — the callee takes
+    ownership and NULLs the caller's pointer via ``T **``.  Self-typed arguments are
+    excluded because the owning struct is never disowned through itself.
+    """
+    resolved_class = owner_class if attrs.get("class") == "self" else attrs.get("class", owner_class)
+    effective_cls_access = attrs.get("access")
+    extra: dict[str, str] = {}
+    resolved_class_str = cast(str, resolved_class)
+    if resolved_class_str.startswith("const "):
+        resolved_class_str = resolved_class_str[len("const "):]
+        extra["is_const_type"] = "1"
+    if attrs.get("library") and attrs.get("class") != "self":
+        type_name = resolved_class_str
+    else:
+        type_name = class_type_symbol(project_ir, resolved_class_str) if project_ir is not None else "vsc_data_t"
+    accessed_by = "value"
+    if attrs.get("class") == "self" and attrs.get("passed_by") == "reference":
+        accessed_by = "reference"
+    elif attrs.get("class") == "self" and project_ir is not None:
+        try:
+            is_value = class_ir(project_ir, owner_class).attrs.get("is_value_type") in {"1", "true"}
+        except (KeyError, ValueError):
+            is_value = False  # implementations are never value types
+        if not is_value:
+            accessed_by = "pointer"
+    elif attrs.get("library") and attrs.get("class") != "self":
+        if (attrs.get("_array") == "given" or attrs.get("array") == "given") and attrs.get("is_reference") in {"1", "true"}:
+            accessed_by = "reference"
+        elif attrs.get("is_reference") == "0":
+            accessed_by = "value"
+        else:
+            accessed_by = "pointer"
+    elif attrs.get("class") != "self" and project_ir is not None:
+        target_is_value_type = False
+        for pir in [project_ir, *getattr(project_ir, 'fallback_projects', [])]:
+            try:
+                target_cls = class_ir(pir, resolved_class_str)
+                target_is_value_type = target_cls.attrs.get("is_value_type") in {"1", "true"}
+                break
+            except (KeyError, ValueError):
+                pass
+        if not target_is_value_type:
+            accessed_by = "pointer"
+    if attrs.get("_array") == "given" or attrs.get("array") == "given":
+        accessed_by = "reference" if attrs.get("is_reference") in {"1", "true"} else "pointer"
+    if effective_cls_access == "readonly" and accessed_by == "pointer":
+        extra["is_const_type"] = "1"
+    if attrs.get("access") == "disown" and attrs.get("class") != "self":
+        return text_element(parent, "c_argument", name=f"{arg_name}_ref", accessed_by="reference", type=type_name, type_is="class", **extra)
+    return text_element(parent, "c_argument", name=arg_name, accessed_by=accessed_by, type=type_name, type_is="class", **extra)
+
+
 def argument_from_source(
     parent: ET.Element,
     src: dict,
@@ -6972,156 +7088,35 @@ def argument_from_source(
 
     Parameters
     ----------
-    parent:
-        The XML element that will receive the new ``c_argument`` child.
     src:
-        An IR argument dict as produced by the IR loader.  Relevant keys:
-
-        * ``interface`` – name of an interface type (mutually exclusive with ``class``/``type``)
-        * ``class``     – name of a class type; the special value ``"self"`` refers to the
-                          owning class resolved via *owner_class*
-        * ``library``   – truthy when the type comes from an external library (skips IR lookup)
-        * ``access``    – pre-resolved access mode: ``"readonly"``, ``"readwrite"``,
-                          ``"writeonly"``, or ``"disown"``
-        * ``project``   – source project name for cross-project interface types
-        * ``name``      – argument name (overridden by the *name* kwarg when provided)
-        * ``passed_by`` – ``"reference"`` forces double-pointer for self-typed args
-        * ``type``      – primitive type tag (``"byte"``, ``"string"``, ``"varargs"``, …)
-
+        IR argument dict with keys: ``interface``, ``class``, ``library``, ``access``
+        (``readonly``/``readwrite``/``writeonly``/``disown``), ``project``, ``name``,
+        ``passed_by``, ``type`` (``byte``/``string``/``varargs``/…).
     name:
-        Override for the argument name; falls back to ``src["name"]`` when ``None``.
+        Override for the argument name; falls back to ``src["name"]``.
     project_ir:
-        IR of the project that owns the method being emitted.  Pass ``None`` when the
-        caller has no project context (e.g. during stand-alone snippet rendering); a
-        best-effort fallback to ``"vscf"`` prefixes is used in that case.
+        IR of the owning project; ``None`` uses ``"vscf"`` fallback prefixes.
     owner_class:
-        The name of the class that owns the method.  Used when ``src["class"] == "self"``
-        to resolve the concrete struct type.
-
-    Returns
-    -------
-    ET.Element
-        The newly created ``c_argument`` element (already attached to *parent*).
+        Owning class name — used when ``src["class"] == "self"`` to resolve the struct type.
 
     Three main dispatch branches
     ----------------------------
-    (a) ``src["interface"]`` is set
-        The argument accepts *any* implementation of the named interface, so it maps to a
-        ``{prefix}_impl_t *`` pointer.  ``effective_access == "disown"`` upgrades to a
-        double-pointer (``**``) with a ``_ref`` name suffix — see inline WHY comments.
-    (b) ``src["class"]`` is set
-        The argument is a concrete struct.  Access mode, value-type flag, and array markers
-        determine whether it is passed by value, pointer, or double-pointer.
-    (c) Fallback (buffer, enum, string, primitive, varargs, callback)
-        All other IR type tags fall through to specialised sub-branches that handle the
-        ``type_map`` primitive table, string conventions, varargs, and callback signatures.
+    (a) ``src["interface"]`` → :func:`_interface_argument_element` (impl_t pointer, disown→ref).
+    (b) ``src["class"]``    → :func:`_class_argument_element` (value/pointer/reference by rules).
+    (c) Fallback: callback, string, enum, varargs, or primitive via ``type_map``.
     """
-    # WHY attrs = src: they are the exact same dict.  ``attrs`` is a local alias kept
-    # for readability — it mirrors the naming convention used throughout the codebase
-    # where "attributes" describes the IR dict entries being interrogated.
-    attrs = src
-    arg_name = name if name is not None else attrs.get("name", "")
-    if attrs.get("interface") is not None:
-        # Interface-typed argument → resolve to {prefix}_impl_t pointer
-        # For cross-project interfaces, use the source project's prefix
-        arg_project = attrs.get("project")
-        if arg_project and project_ir is not None:
-            prefix = project_ir.prefix  # default
-            # WHY fallback_projects loop: when an interface is declared in a *different*
-            # project (e.g. a ``common`` interface referenced from ``foundation``), the
-            # impl_t type must carry that dependency's prefix, not the current project's
-            # prefix.  ``fallback_projects`` is the list of project IRs that were loaded
-            # as transitive dependencies, so we scan it to find the right prefix instead
-            # of hard-coding the cross-project name.
-            for fp in (project_ir.fallback_projects or []):
-                if fp.name == arg_project:
-                    prefix = fp.prefix
-                    break
-        else:
-            prefix = project_ir.prefix if project_ir is not None else "vscf"
-        type_name = f"{prefix}_impl_t"
-        extra: dict[str, str] = {}
-        # WHY effective_access vs raw attrs.get("access"): access is fully resolved in
-        # the IR (inheritances, defaults applied) before reaching this function, so we
-        # read it once into ``effective_access`` and treat it as the canonical value
-        # rather than re-reading the raw key multiple times.
-        effective_access = attrs.get("access", "readonly")
-        if effective_access == "readonly":
-            extra["is_const_type"] = "1"
-        # WHY "disown" produces a _ref suffix with double-pointer (reference) access:
-        # the "disown" convention signals transfer-of-ownership — the callee takes
-        # exclusive ownership of the object and NULLs the caller's pointer.  C
-        # represents this as a ``T **`` parameter (double pointer), and the ``_ref``
-        # suffix makes the intent visible at the call site.
-        if effective_access == "disown":
-            return text_element(parent, "c_argument", name=f"{arg_name}_ref", accessed_by="reference", type=type_name, type_is="class", **extra)
-        return text_element(parent, "c_argument", name=arg_name, accessed_by="pointer", type=type_name, type_is="class", **extra)
-    if attrs.get("class") is not None:
-        resolved_class = owner_class if attrs.get("class") == "self" else attrs.get("class", owner_class)
-        # Access is pre-resolved in the IR
-        effective_cls_access = attrs.get("access")
-        extra: dict[str, str] = {}
-        # Handle const prefix in class name
-        resolved_class_str = cast(str, resolved_class)
-        if resolved_class_str.startswith("const "):
-            resolved_class_str = resolved_class_str[len("const "):]
-            extra["is_const_type"] = "1"
-        if attrs.get("library") and attrs.get("class") != "self":
-            # External or internal library type — use name as-is without IR lookup
-            type_name = resolved_class_str
-        else:
-            type_name = class_type_symbol(project_ir, resolved_class_str) if project_ir is not None else "vsc_data_t"
-        accessed_by = "value"
-        if attrs.get("class") == "self" and attrs.get("passed_by") == "reference":
-            accessed_by = "reference"
-        elif attrs.get("class") == "self" and project_ir is not None:
-            try:
-                is_value = class_ir(project_ir, owner_class).attrs.get("is_value_type") in {"1", "true"}
-            except (KeyError, ValueError):
-                is_value = False  # implementations are never value types
-            if not is_value:
-                accessed_by = "pointer"
-        elif attrs.get("library") and attrs.get("class") != "self":
-            # Library types default to pointer; only value when explicitly is_reference="0".
-            # Array out-parameters such as nanopb repeated fields use a double pointer.
-            if (attrs.get("_array") == "given" or attrs.get("array") == "given") and attrs.get("is_reference") in {"1", "true"}:
-                accessed_by = "reference"
-            elif attrs.get("is_reference") == "0":
-                accessed_by = "value"
-            else:
-                accessed_by = "pointer"
-        elif attrs.get("class") != "self" and project_ir is not None:
-            # Non-self class argument: check if target class is a value type
-            target_is_value_type = False
-            for pir in [project_ir, *getattr(project_ir, 'fallback_projects', [])]:
-                try:
-                    target_cls = class_ir(pir, resolved_class_str)
-                    target_is_value_type = target_cls.attrs.get("is_value_type") in {"1", "true"}
-                    break
-                except (KeyError, ValueError):
-                    pass
-            if not target_is_value_type:
-                accessed_by = "pointer"
-        # Array arguments are pointer-backed in C. When the model also marks the
-        # argument as a reference, preserve the double-pointer form.
-        if attrs.get("_array") == "given" or attrs.get("array") == "given":
-            accessed_by = "reference" if attrs.get("is_reference") in {"1", "true"} else "pointer"
-        # Only apply const for readonly pointer types (not value types)
-        if effective_cls_access == "readonly" and accessed_by == "pointer":
-            extra["is_const_type"] = "1"
-        # WHY "disown" produces a _ref suffix with double-pointer (reference) access:
-        # same transfer-of-ownership convention as for interface-typed args above — the
-        # callee takes ownership and NULLs the caller's pointer via ``T **``.  Self-typed
-        # arguments are excluded because the owning struct is never disowned through itself.
-        if attrs.get("access") == "disown" and attrs.get("class") != "self":
-            return text_element(parent, "c_argument", name=f"{arg_name}_ref", accessed_by="reference", type=type_name, type_is="class", **extra)
-        return text_element(parent, "c_argument", name=arg_name, accessed_by=accessed_by, type=type_name, type_is="class", **extra)
-    if attrs.get("callback") is not None:
-        callback_type = callback_symbol(project_ir, callback_name_from_ref(attrs.get("callback"))) if project_ir is not None else "vsc_dealloc_fn"
+    arg_name = name if name is not None else src.get("name", "")
+    if src.get("interface") is not None:
+        return _interface_argument_element(parent, src, arg_name, project_ir)
+    if src.get("class") is not None:
+        return _class_argument_element(parent, src, arg_name, owner_class, project_ir)
+    # callback: function-pointer argument — resolve to the typed fn alias (e.g. vsc_dealloc_fn)
+    if src.get("callback") is not None:
+        callback_type = callback_symbol(project_ir, callback_name_from_ref(src.get("callback"))) if project_ir is not None else "vsc_dealloc_fn"
         return text_element(parent, "c_argument", name=c_identifier(arg_name, callback=True), accessed_by="value", type=callback_type, type_is="callback")
-    if attrs.get("type") == "string":
-        if attrs.get("string_length") == "fixed" and attrs.get("string_length_constant"):
-            # Fixed-length writable string buffer: char name[N]
+    # string: fixed-length char array (char name[N]) or null-terminated const char*
+    if src.get("type") == "string":
+        if src.get("string_length") == "fixed" and src.get("string_length_constant"):
             return text_element(
                 parent,
                 "c_argument",
@@ -7129,10 +7124,9 @@ def argument_from_source(
                 accessed_by="value",
                 type="char",
                 type_is="primitive",
-                array=attrs["string_length_constant"],
+                array=src["string_length_constant"],
             )
-        # Default: null-terminated const string: const char *name
-        is_const = "1" if attrs.get("access") in ("readonly", None) else None
+        is_const = "1" if src.get("access") in ("readonly", None) else None
         return text_element(
             parent,
             "c_argument",
@@ -7143,11 +7137,10 @@ def argument_from_source(
             string="given",
             **({"is_const_type": "1"} if is_const else {}),
         )
-    if attrs.get("enum") is not None:
-        # Enum-typed argument → resolve to enum type
-        enum_name = attrs["enum"]
-        if attrs.get("library"):
-            # External library enum type — use raw name as-is
+    # enum: resolve to the typed enum_t symbol; library enums use the raw name as-is
+    if src.get("enum") is not None:
+        enum_name = src["enum"]
+        if src.get("library"):
             rendered_type = enum_name
         elif project_ir is not None:
             try:
@@ -7158,17 +7151,19 @@ def argument_from_source(
         else:
             rendered_type = f"vscf_{snake_name(enum_name)}_t"
         return text_element(parent, "c_argument", name=arg_name, accessed_by="value", type=rendered_type, type_is="primitive")
-    if attrs.get("type") == "varargs":
+    # varargs: the C ellipsis — no name, no type, just "..."
+    if src.get("type") == "varargs":
         return text_element(parent, "c_argument", type="...", accessed_by="value")
-    rendered_type, kind = type_map(attrs.get("type"), attrs.get("size"))
+    # primitive (byte, size, bool, …): look up C type via type_map; byte arrays are pointer/reference
+    rendered_type, kind = type_map(src.get("type"), src.get("size"))
     extra = {}
-    if attrs.get("type") == "byte" and attrs.get("_array") == "given":
+    if src.get("type") == "byte" and src.get("_array") == "given":
         extra["array"] = "given"
-        if attrs.get("access") not in ("readwrite", "writeonly"):
+        if src.get("access") not in ("readwrite", "writeonly"):
             extra["is_const_type"] = "1"
-    elif attrs.get("type") == "byte" and attrs.get("is_reference") in {"1", "true"} and attrs.get("access") != "readwrite":
+    elif src.get("type") == "byte" and src.get("is_reference") in {"1", "true"} and src.get("access") != "readwrite":
         extra["is_const_type"] = "1"
-    accessed_by = "pointer" if attrs.get("is_reference") in {"1", "true"} else "value"
+    accessed_by = "pointer" if src.get("is_reference") in {"1", "true"} else "value"
     return text_element(parent, "c_argument", name=arg_name, accessed_by=accessed_by, type=rendered_type, type_is=kind, **extra)
 
 


### PR DESCRIPTION
## Summary

Continuation of the codegen maintainability optimization run (mean score 4.4 → 4.6):

- Extract `_merge_header_includes` from `render_one` — the 80-line inline include merge block becomes a named helper with a full docstring explaining the four-source merge, cross-project filtering, and stale-artifact removal rationale
- Extract `_interface_argument_element` and `_class_argument_element` from `argument_from_source` — the 142-line function becomes a clean dispatcher; complex branch rules (accessed_by precedence, disown/ref naming, fallback_projects loop) live in focused helpers with dedicated docstrings
- Compact `render_one` docstring (was 60 lines, now 8) so the full function body is visible to readers; add two-pass loop comment
- Remove `attrs = src` alias from `argument_from_source`; annotate all fallback branches (callback, string, enum, varargs, primitive) with inline purpose comments

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` — syntax OK on both files
- [x] `pytest tools/codegen/test_*.py` — 96 passed, 4 deselected (pre-existing skips)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)