### PR TITLE
refactor(ci): single-pipeline release — call publish workflows directly from release.yml

### DIFF
--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -13,6 +13,11 @@ on:
       - develop
       - main
   workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout'
+        type: string
+        default: ''
     outputs:
       version:
         description: "Project version"
@@ -26,6 +31,8 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Extract version
         id: version
@@ -40,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -79,6 +88,8 @@ jobs:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -117,6 +128,8 @@ jobs:
     runs-on: macos-14  # M1/ARM runner
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -150,6 +163,8 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -188,6 +203,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -225,6 +242,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -262,6 +281,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -299,6 +320,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -338,6 +361,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Java
         uses: actions/setup-java@v5

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -1,7 +1,12 @@
 name: Build PHP
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout'
+        type: string
+        default: ''
   push:
     branches:
       - develop
@@ -158,6 +163,8 @@ jobs:
 
       - name: Checkout project
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Configure project
         shell: cmd
@@ -208,6 +215,8 @@ jobs:
         run: php -v
 
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -286,6 +295,8 @@ jobs:
         run: php -v
 
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -12,6 +12,11 @@ on:
       - develop
       - main
   workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout'
+        type: string
+        default: ''
 
 jobs:
   build-wheels:
@@ -41,6 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ref || '' }}
           submodules: recursive
 
       - uses: actions/setup-python@v6
@@ -117,6 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ref || '' }}
           submodules: recursive
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -18,6 +18,10 @@ on:
         description: 'Upload dist as a workflow artifact for release'
         type: boolean
         default: false
+      ref:
+        description: 'Git ref to checkout'
+        type: string
+        default: ''
 
 jobs:
   build-and-test:
@@ -25,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -1,21 +1,23 @@
 name: Release Java
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      tag:
-        description: 'Tag to release'
-        required: true
+      version:
+        description: 'Version string (e.g. 0.19.0-rc.1)'
         type: string
+        required: true
+      ref:
+        description: 'Git ref to build from (e.g. refs/tags/v0.19.0-rc.1)'
+        type: string
+        required: true
 
 jobs:
   build:
     name: Build Binaries
     uses: ./.github/workflows/build-java.yml
+    with:
+      ref: ${{ inputs.ref }}
 
   publish-jvm-release:
     name: Publish JVM Release
@@ -24,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          ref: ${{ inputs.ref }}
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -61,14 +63,9 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: Verify version matches tag
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         working-directory: wrappers/java
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG=${{ inputs.tag }}
-          else
-            TAG=${GITHUB_REF#refs/tags/}
-          fi
+          TAG=v${{ inputs.version }}
           TAG_VERSION=${TAG#v}
           # Use Maven to evaluate the effective project version (more robust than grepping XML).
           POM_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tr -d '[:space:]')
@@ -100,7 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          ref: ${{ inputs.ref }}
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -128,14 +125,9 @@ jobs:
           ls -la
 
       - name: Verify version matches tag
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         working-directory: wrappers/java/android
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG=${{ inputs.tag }}
-          else
-            TAG=${GITHUB_REF#refs/tags/}
-          fi
+          TAG=v${{ inputs.version }}
           TAG_VERSION=${TAG#v}
           # Ask Gradle for the effective project version (no parsing of 'properties' output).
           GRADLE_VERSION=$(./gradlew -q printVersion | tr -d '[:space:]')
@@ -264,7 +256,7 @@ jobs:
             --fail \
             --header "Authorization: Bearer ${CENTRAL_BEARER}" \
             --form "bundle=@build/central-bundle.zip" \
-            "https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC&name=${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}")
+            "https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC&name=v${{ inputs.version }}")
 
           if [ -z "${DEPLOYMENT_ID}" ]; then
             echo "ERROR: Central Portal did not return a deployment ID"
@@ -303,22 +295,3 @@ jobs:
           echo "Timed out waiting for Central Portal publish"
           exit 1
 
-      - name: Create GitHub Release
-        if: github.event_name == 'push' && !contains(github.ref, '-rc')
-        uses: softprops/action-gh-release@v1
-        with:
-          generate_release_notes: true
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create GitHub Pre-release (RC)
-        if: github.event_name == 'push' && contains(github.ref, '-rc')
-        uses: softprops/action-gh-release@v1
-        with:
-          generate_release_notes: true
-          draft: false
-          prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-php.yml
+++ b/.github/workflows/release-php.yml
@@ -1,15 +1,23 @@
 name: Release PHP
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version string (e.g. 0.19.0-rc.1)'
+        type: string
+        required: true
+      ref:
+        description: 'Git ref to build from (e.g. refs/tags/v0.19.0-rc.1)'
+        type: string
+        required: true
 
 jobs:
   build-php:
     name: Build PHP Packages
     uses: ./.github/workflows/build-php.yml
+    with:
+      ref: ${{ inputs.ref }}
 
   publish-php-assets:
     name: Publish PHP Assets
@@ -26,6 +34,7 @@ jobs:
       - name: Upload PHP assets to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ inputs.version }}
           files: |
             dist/**/*.zip
             dist/**/*.tar.gz

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,13 +1,21 @@
 name: Release Python
 on:
-  push:
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version string (e.g. 0.19.0-rc.1)'
+        type: string
+        required: true
+      ref:
+        description: 'Git ref to build from (e.g. refs/tags/v0.19.0-rc.1)'
+        type: string
+        required: true
 
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-python.yml
+    with:
+      ref: ${{ inputs.ref }}
 
   is-prerelease:
     name: Check if pre-release
@@ -18,7 +26,7 @@ jobs:
       - name: Detect pre-release tag
         id: check
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="v${{ inputs.version }}"
           # A tag with a hyphen after the version (e.g. v0.17.3-rc1, v1.0.0-alpha1)
           # indicates a pre-release
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -1,34 +1,51 @@
 name: Release Swift
 on:
-  push:
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version string (e.g. 0.19.0-rc.1)'
+        type: string
+        required: true
 jobs:
   verify-spm:
     name: Verify SPM with released binaries
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: refs/tags/v${{ inputs.version }}
+
+      - name: Download xcframework artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: apple-release-files
+          path: _apple-artifact
+
+      - name: Stage xcframeworks locally
+        run: |
+          mkdir -p binaries/
+          cp _apple-artifact/binaries/*.xcframework.zip binaries/
+          cp _apple-artifact/binaries/*.xcframework.zip.sha256sum binaries/
 
       - name: Check Xcode
         run: |
           xcode-select -p
           xcodebuild -version
 
-      - name: Wait for xcframework assets on the release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG="${{ github.ref_name }}"
-          for i in $(seq 1 20); do
-            COUNT=$(gh release view "$TAG" --json assets --jq '.assets | length' 2>/dev/null || echo 0)
-            [ "$COUNT" -gt 0 ] && { echo "Release assets ready ($COUNT files)"; exit 0; }
-            echo "Waiting for release assets... attempt $i/20"
-            sleep 30
-          done
-          echo "ERROR: release assets did not appear after 10 minutes"
-          exit 1
+      - name: Check that SPM has correct xcframeworks hash
+        run: ./scripts/check_spm_xcframeworks.sh
+
+      - name: Test SPM with local binaries
+        run: ./scripts/run_spm_tests_with_local_binaries.sh
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          prerelease: ${{ contains(inputs.version, '-') }}
+          files: |
+            binaries/*.xcframework.zip
+            binaries/*.xcframework.zip.sha256sum
 
       - name: Test SPM with released binaries
         run: swift test

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -1,16 +1,23 @@
 name: Release WASM
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version string (e.g. 0.19.0-rc.1)'
+        type: string
+        required: true
+      ref:
+        description: 'Git ref to build from (e.g. refs/tags/v0.19.0-rc.1)'
+        type: string
+        required: true
 
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-wasm.yml
     with:
       upload_artifacts: true
+      ref: ${{ inputs.ref }}
 
   is-prerelease:
     name: Check if pre-release
@@ -21,7 +28,7 @@ jobs:
       - name: Detect pre-release tag
         id: check
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="v${{ inputs.version }}"
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -38,6 +45,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -65,6 +74,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
         default: 'develop'
         type: string
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   validate:
     name: Validate inputs
@@ -68,8 +72,6 @@ jobs:
     name: Release Commit & Tag
     needs: [build-go, build-apple]
     runs-on: macos-26
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -145,8 +147,9 @@ jobs:
 
       - name: Commit release binaries
         run: |
-          # xcframeworks ship as GitHub Release assets, not in git — remove before staging
+          # xcframeworks and download artifacts must not be committed
           rm -f binaries/*.xcframework.zip binaries/*.xcframework.zip.sha256sum
+          rm -rf _apple-artifact/
           git add -A
           git diff --cached --quiet || git commit -m "chore(release): bump version and update pre-built binaries for v${{ inputs.version }}"
 
@@ -160,20 +163,45 @@ jobs:
           git tag -l "v${{ inputs.version }}" | grep -q . || git tag "v${{ inputs.version }}" -m "v${{ inputs.version }}"
           git push origin "refs/tags/wrappers/go/v${{ inputs.version }}" "refs/tags/v${{ inputs.version }}"
 
-      - name: Create GitHub Release with xcframeworks
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION="${{ inputs.version }}"
-          [[ "$VERSION" == *-* ]] && PRERELEASE="--prerelease" || PRERELEASE=""
-          # Create release; fall back to uploading assets if the release already exists (re-run)
-          gh release create "v${VERSION}" \
-            _apple-artifact/binaries/*.xcframework.zip \
-            _apple-artifact/binaries/*.xcframework.zip.sha256sum \
-            --title "v${VERSION}" \
-            --notes "" \
-            $PRERELEASE \
-          || gh release upload "v${VERSION}" \
-            _apple-artifact/binaries/*.xcframework.zip \
-            _apple-artifact/binaries/*.xcframework.zip.sha256sum \
-            --clobber
+
+  publish-php:
+    name: Publish PHP
+    needs: [release-commit]
+    uses: ./.github/workflows/release-php.yml
+    with:
+      version: ${{ inputs.version }}
+      ref: refs/tags/v${{ inputs.version }}
+
+  publish-java:
+    name: Publish Java
+    needs: [release-commit]
+    uses: ./.github/workflows/release-java.yml
+    with:
+      version: ${{ inputs.version }}
+      ref: refs/tags/v${{ inputs.version }}
+    secrets: inherit
+
+  publish-python:
+    name: Publish Python
+    needs: [release-commit]
+    uses: ./.github/workflows/release-python.yml
+    with:
+      version: ${{ inputs.version }}
+      ref: refs/tags/v${{ inputs.version }}
+    secrets: inherit
+
+  publish-wasm:
+    name: Publish WASM
+    needs: [release-commit]
+    uses: ./.github/workflows/release-wasm.yml
+    with:
+      version: ${{ inputs.version }}
+      ref: refs/tags/v${{ inputs.version }}
+    secrets: inherit
+
+  verify-swift:
+    name: Verify Swift SPM
+    needs: [release-commit]
+    uses: ./.github/workflows/release-swift.yml
+    with:
+      version: ${{ inputs.version }}


### PR DESCRIPTION
## Summary

- Replaces broken `push: tags:` triggers on all `release-*.yml` with `workflow_call` — GITHUB_TOKEN-pushed tags cannot trigger other workflows by design, so PHP/Java/Python/WASM/Swift never fired for rc.1 or rc.2
- `release.yml` now drives all 5 publish jobs (`publish-php`, `publish-java`, `publish-python`, `publish-wasm`, `verify-swift`) directly after `release-commit` via `uses:`
- Adds `ref` input to all `build-*.yml` so each build job checks out the exact release tag rather than branch tip
- Fixes `_apple-artifact/` being accidentally committed (`rm -rf` before `git add -A`)
- Moves xcframework GitHub Release upload into `release-swift.yml` (the old step in `release-commit` tried to upload from `_apple-artifact/` after it was already deleted)

## Why this must land on main before the next RC

`workflow_dispatch` reads `release.yml` from the **default branch** (`main`), regardless of the `branch` input. Without this PR on main, triggering another RC would still use the old broken pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)