### PR TITLE
docs(readme): add per-wrapper build badges and pin all to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 # Virgil Security Crypto Library for C
 
-[![Build Linux](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-linux.yml/badge.svg)](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-linux.yml)
-[![Build macOS](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-macos.yml/badge.svg)](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-macos.yml)
+[![Build Linux](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-linux.yml/badge.svg?branch=develop)](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-linux.yml?query=branch%3Adevelop)
+[![Build macOS](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-macos.yml/badge.svg?branch=develop)](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-macos.yml?query=branch%3Adevelop)
+[![Build Go](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-go.yml/badge.svg?branch=develop)](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-go.yml?query=branch%3Adevelop)
+[![Build Java](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-java.yml/badge.svg?branch=develop)](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-java.yml?query=branch%3Adevelop)
+[![Build PHP](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-php.yml/badge.svg?branch=develop)](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-php.yml?query=branch%3Adevelop)
+[![Build Python](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-python.yml/badge.svg?branch=develop)](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-python.yml?query=branch%3Adevelop)
+[![Build WASM](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-wasm.yml/badge.svg?branch=develop)](https://github.com/VirgilSecurity/virgil-crypto-c/actions/workflows/build-wasm.yml?query=branch%3Adevelop)
 [![Swift Package Manager](https://img.shields.io/badge/Swift_Package_Manager-compatible-orange?style=flat)](https://www.swift.org/package-manager/)
 
 


### PR DESCRIPTION
Adds Build Go / Java / PHP / Python / WASM status badges alongside the existing Linux / macOS ones, so the README header reflects every CI build workflow.

All build badges now point at the `develop` branch (`?branch=develop`), where CI runs continuously. Previously they tracked the default branch (`main`), whose latest build is the cancelled #197 merge from May — so they rendered red ("failing") even though every `develop` build is green. The Swift Package Manager badge stays as the static "compatible" shield (it is not a CI workflow).

Docs-only; commit carries `[skip ci]`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)