### PR TITLE
fix(ci): make release merge-to-main actually run and fail loudly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,20 +242,32 @@ jobs:
       BRANCH: ${{ inputs.branch }}
       VERSION: ${{ inputs.version }}
     steps:
-      - name: Create PR
-        run: |
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore(release): merge v${VERSION} to main" \
-            --body "Automated merge of release v${VERSION} from \`${BRANCH}\` to \`main\`." \
-            || true
+      # Checkout is required: gh derives the repository from the git remote, and
+      # without it `gh pr create`/`gh pr list` fail with "not a git repository".
+      - uses: actions/checkout@v6
 
-      - name: Merge PR
+      - name: Merge release branch to main
         run: |
-          PR=$(gh pr list --base main --head "$BRANCH" --json number | jq -r '.[0].number // empty')
-          if [ -n "$PR" ]; then
-            gh pr merge "$PR" --merge
-          else
-            echo "Nothing to merge"
+          set -euo pipefail
+
+          PR=$(gh pr list --base main --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$PR" ]; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(release): merge v${VERSION} to main" \
+              --body "Automated merge of release v${VERSION} from \`${BRANCH}\` to \`main\`."
+            PR=$(gh pr list --base main --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
           fi
+
+          if [ -z "$PR" ]; then
+            echo "::error::Could not create or locate a ${BRANCH}->main PR for v${VERSION}"
+            exit 1
+          fi
+
+          echo "Merging PR #${PR} into main"
+          # --admin bypasses required reviews on the protected main branch. This needs the
+          # Actions token to be a branch-protection bypass actor; if it is not, this step
+          # fails loudly (instead of the previous silent success) and a maintainer merges
+          # PR #${PR} manually.
+          gh pr merge "$PR" --merge --admin


### PR DESCRIPTION
The `merge-to-main` job in `release.yml` reported success on every release but never updated `main`. It has no `actions/checkout`, so `gh` ran with no git context (`fatal: not a git repository`); `gh pr create` failed silently behind `|| true`, `gh pr list` found nothing, and the job printed "Nothing to merge" and went green. As a result `main` drifted **64 commits** behind `develop` across the 0.19.x and 0.20.0 releases — the same root cause behind the stale build badges and the Dependabot fix never reaching `main`.

## Fix
- Add `actions/checkout@v6` so `gh` can resolve the repository.
- Run the step under `set -euo pipefail` and drop the `|| true` mask.
- Reuse an existing open `develop`→`main` PR if one is present, otherwise create one, and exit non-zero if neither create nor lookup yields a PR.
- Merge with `--admin` to bypass the required review on protected `main`.

## Note for maintainers
`--admin` only works if the GitHub Actions token is a branch-protection **bypass actor** for `main`. If it is not, the merge step now **fails visibly** (instead of the previous silent success) and a maintainer merges the PR manually — which is the honest outcome for a review-protected branch. If you want this fully automated, add `github-actions[bot]` as a bypass actor in `main`'s protection rules.

The 0.20.0 release's `main` merge was completed manually (PR #202); this prevents the silent failure from recurring.