### PR TITLE
docs(readme): update post-quantum algorithms (Round5 → ML-KEM/ML-DSA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ This library contains basic cryptographic algorithms and can be used as building
 | Key Generation, PRNG        | CTR_DRBG [NIST SP 800-90A](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90Ar1.pdf)                                                                           |
 | Key Derivation              | [KDF1, KDF2](https://www.shoup.net/iso/std6.pdf),  [HKDF](https://tools.ietf.org/html/rfc5869), [PBKDF2](https://tools.ietf.org/html/rfc8018#section-5.2)                        |
 | Key Exchange                | [X25519](https://tools.ietf.org/html/rfc7748), [RSA](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Br1.pdf), [ECDH](https://www.secg.org/sec1-v2.pdf)       |
-| Key Encapsulation Mechanism | [Round5](https://github.com/round5/code), ECIES-KEM                                                                                                                              |
+| Key Encapsulation Mechanism | [ML-KEM-768](https://csrc.nist.gov/pubs/fips/203/final), ECIES-KEM                                                                                                                |
 | Hashing                     | [SHA-2 (224/256/384/512)](https://tools.ietf.org/html/rfc4634)                                                                                                                   |
 | Message Authentication Code | [HMAC](https://www.ietf.org/rfc/rfc2104.txt)                                                                                                                                     |
-| Digital Signature           | [Ed25519](https://tools.ietf.org/html/rfc8032), [RSASSA-PSS](https://tools.ietf.org/html/rfc4056), [ECDSA](https://www.secg.org/sec1-v2.pdf), [Falcon](https://falcon-sign.info) |
+| Digital Signature           | [Ed25519](https://tools.ietf.org/html/rfc8032), [RSASSA-PSS](https://tools.ietf.org/html/rfc4056), [ECDSA](https://www.secg.org/sec1-v2.pdf), [Falcon](https://falcon-sign.info), [ML-DSA-65](https://csrc.nist.gov/pubs/fips/204/final) |
 | Entropy Source              | Linux, macOS [/dev/urandom](https://tls.mbed.org/module-level-design-rng),<br>Windows [CryptGenRandom()](https://tls.mbed.org/module-level-design-rng)                           |
-| Symmetric Algorithms        | [AES-256-GCM](http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf), [AES-256-CBC](https://tools.ietf.org/html/rfc3602)                                  |
+| Symmetric Algorithms        | [AES-256-GCM](http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf), [AES-256-CBC](https://tools.ietf.org/html/rfc3602), [AES-128/256 Key Wrap](https://tools.ietf.org/html/rfc3394)                                  |
 | Encryption schemes          | [PBES2](https://tools.ietf.org/html/rfc8018#section-6.2)                                                                                                                         |
 | Elliptic Curves             | [Ed25519](https://tools.ietf.org/html/rfc8032), [Curve25519](https://tools.ietf.org/html/rfc7748), [secp256R1](https://www.secg.org/sec1-v2.pdf)                                 |
-| Post-quantum cryptography   | [Falcon](https://falcon-sign.info), [Round5](https://github.com/round5/code)                                                                                                     |
+| Post-quantum cryptography   | [ML-KEM-768](https://csrc.nist.gov/pubs/fips/203/final), [ML-DSA-65](https://csrc.nist.gov/pubs/fips/204/final), [Falcon](https://falcon-sign.info)                               |
 
 ### Library: PHE
 


### PR DESCRIPTION
The README algorithm table still listed **Round5**, which was removed in 0.19.1 and replaced by the standalone `mlkem-native` / `mldsa-native` libraries. Brings the table in line with what the library actually ships:

- **Key Encapsulation Mechanism**: Round5 → **ML-KEM-768** (FIPS 203)
- **Digital Signature**: add **ML-DSA-65** (FIPS 204) alongside Ed25519/RSASSA-PSS/ECDSA/Falcon
- **Post-quantum cryptography**: **ML-KEM-768 + ML-DSA-65 + Falcon** (Round5 removed)
- **Symmetric Algorithms**: add **AES-128/256 Key Wrap** (RFC 3394), new in 0.20.0

Docs-only; commit carries `[skip ci]`.