### PR TITLE
chore: sync main with develop — message-info parse fix, release CI fix, README update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,20 +242,32 @@ jobs:
       BRANCH: ${{ inputs.branch }}
       VERSION: ${{ inputs.version }}
     steps:
-      - name: Create PR
-        run: |
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore(release): merge v${VERSION} to main" \
-            --body "Automated merge of release v${VERSION} from \`${BRANCH}\` to \`main\`." \
-            || true
+      # Checkout is required: gh derives the repository from the git remote, and
+      # without it `gh pr create`/`gh pr list` fail with "not a git repository".
+      - uses: actions/checkout@v6
 
-      - name: Merge PR
+      - name: Merge release branch to main
         run: |
-          PR=$(gh pr list --base main --head "$BRANCH" --json number | jq -r '.[0].number // empty')
-          if [ -n "$PR" ]; then
-            gh pr merge "$PR" --merge
-          else
-            echo "Nothing to merge"
+          set -euo pipefail
+
+          PR=$(gh pr list --base main --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$PR" ]; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(release): merge v${VERSION} to main" \
+              --body "Automated merge of release v${VERSION} from \`${BRANCH}\` to \`main\`."
+            PR=$(gh pr list --base main --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
           fi
+
+          if [ -z "$PR" ]; then
+            echo "::error::Could not create or locate a ${BRANCH}->main PR for v${VERSION}"
+            exit 1
+          fi
+
+          echo "Merging PR #${PR} into main"
+          # --admin bypasses required reviews on the protected main branch. This needs the
+          # Actions token to be a branch-protection bypass actor; if it is not, this step
+          # fails loudly (instead of the previous silent success) and a maintainer merges
+          # PR #${PR} manually.
+          gh pr merge "$PR" --merge --admin

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ This library contains basic cryptographic algorithms and can be used as building
 | Key Generation, PRNG        | CTR_DRBG [NIST SP 800-90A](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90Ar1.pdf)                                                                           |
 | Key Derivation              | [KDF1, KDF2](https://www.shoup.net/iso/std6.pdf),  [HKDF](https://tools.ietf.org/html/rfc5869), [PBKDF2](https://tools.ietf.org/html/rfc8018#section-5.2)                        |
 | Key Exchange                | [X25519](https://tools.ietf.org/html/rfc7748), [RSA](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Br1.pdf), [ECDH](https://www.secg.org/sec1-v2.pdf)       |
-| Key Encapsulation Mechanism | [Round5](https://github.com/round5/code), ECIES-KEM                                                                                                                              |
+| Key Encapsulation Mechanism | [ML-KEM-768](https://csrc.nist.gov/pubs/fips/203/final), ECIES-KEM                                                                                                                |
 | Hashing                     | [SHA-2 (224/256/384/512)](https://tools.ietf.org/html/rfc4634)                                                                                                                   |
 | Message Authentication Code | [HMAC](https://www.ietf.org/rfc/rfc2104.txt)                                                                                                                                     |
-| Digital Signature           | [Ed25519](https://tools.ietf.org/html/rfc8032), [RSASSA-PSS](https://tools.ietf.org/html/rfc4056), [ECDSA](https://www.secg.org/sec1-v2.pdf), [Falcon](https://falcon-sign.info) |
+| Digital Signature           | [Ed25519](https://tools.ietf.org/html/rfc8032), [RSASSA-PSS](https://tools.ietf.org/html/rfc4056), [ECDSA](https://www.secg.org/sec1-v2.pdf), [Falcon](https://falcon-sign.info), [ML-DSA-65](https://csrc.nist.gov/pubs/fips/204/final) |
 | Entropy Source              | Linux, macOS [/dev/urandom](https://tls.mbed.org/module-level-design-rng),<br>Windows [CryptGenRandom()](https://tls.mbed.org/module-level-design-rng)                           |
-| Symmetric Algorithms        | [AES-256-GCM](http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf), [AES-256-CBC](https://tools.ietf.org/html/rfc3602)                                  |
+| Symmetric Algorithms        | [AES-256-GCM](http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf), [AES-256-CBC](https://tools.ietf.org/html/rfc3602), [AES-128/256 Key Wrap](https://tools.ietf.org/html/rfc3394)                                  |
 | Encryption schemes          | [PBES2](https://tools.ietf.org/html/rfc8018#section-6.2)                                                                                                                         |
 | Elliptic Curves             | [Ed25519](https://tools.ietf.org/html/rfc8032), [Curve25519](https://tools.ietf.org/html/rfc7748), [secp256R1](https://www.secg.org/sec1-v2.pdf)                                 |
-| Post-quantum cryptography   | [Falcon](https://falcon-sign.info), [Round5](https://github.com/round5/code)                                                                                                     |
+| Post-quantum cryptography   | [ML-KEM-768](https://csrc.nist.gov/pubs/fips/203/final), [ML-DSA-65](https://csrc.nist.gov/pubs/fips/204/final), [Falcon](https://falcon-sign.info)                               |
 
 ### Library: PHE
 

--- a/library/foundation/src/vscf_message_info_der_serializer.c
+++ b/library/foundation/src/vscf_message_info_der_serializer.c
@@ -2474,7 +2474,17 @@ vscf_message_info_der_serializer_deserialize(
     //  Read: VirgilMessageInfo
     //
     vscf_asn1_reader_reset(self->asn1_reader, data);
-    vscf_asn1_reader_read_sequence(self->asn1_reader);
+    const size_t message_info_len = vscf_asn1_reader_read_sequence(self->asn1_reader);
+
+    //  The optional fields below live inside the VirgilMessageInfo SEQUENCE. Reads must stop at the
+    //  end of that SEQUENCE, not at the end of `data` — a caller may pass a buffer that has trailing
+    //  bytes after the message info (e.g. the whole ciphertext stream). `left_len()` counts to the
+    //  end of `data`, so capture the floor value it reaches once the SEQUENCE content is consumed and
+    //  gate every optional read on it. Without this, a trailing byte of 0xA0..0xA3 is misread as an
+    //  optional [0]..[3] field and parsing the following bytes fails intermittently.
+    const size_t left_after_header = vscf_asn1_reader_left_len(self->asn1_reader);
+    const size_t message_info_end_left =
+            (left_after_header > message_info_len) ? (left_after_header - message_info_len) : 0;
 
     //
     //  Read: version
@@ -2496,7 +2506,7 @@ vscf_message_info_der_serializer_deserialize(
     //
     //  Read: customParams [0] OPTIONAL
     //
-    if (vscf_asn1_reader_left_len(self->asn1_reader)) {
+    if (vscf_asn1_reader_left_len(self->asn1_reader) > message_info_end_left) {
         const size_t custom_params_tag_len = vscf_asn1_reader_read_context_tag(self->asn1_reader, 0);
         if (custom_params_tag_len != 0) {
             vscf_message_info_custom_params_t *custom_params = vscf_message_info_custom_params(message_info);
@@ -2507,7 +2517,7 @@ vscf_message_info_der_serializer_deserialize(
     //
     //  Read: cipherKdf [1] OPTIONAL
     //
-    if (vscf_asn1_reader_left_len(self->asn1_reader)) {
+    if (vscf_asn1_reader_left_len(self->asn1_reader) > message_info_end_left) {
         const size_t cipher_kdf_tag_len = vscf_asn1_reader_read_context_tag(self->asn1_reader, 1);
         if (cipher_kdf_tag_len != 0) {
             vscf_message_info_der_serializer_deserialize_cipher_kdf(self, message_info, &error_ctx);
@@ -2517,7 +2527,7 @@ vscf_message_info_der_serializer_deserialize(
     //
     //  Read: footerInfo [2] OPTIONAL
     //
-    if (vscf_asn1_reader_left_len(self->asn1_reader)) {
+    if (vscf_asn1_reader_left_len(self->asn1_reader) > message_info_end_left) {
         const size_t footer_info_tag_len = vscf_asn1_reader_read_context_tag(self->asn1_reader, 2);
         if (footer_info_tag_len != 0) {
             vscf_message_info_der_serializer_deserialize_footer_info(self, message_info, &error_ctx);
@@ -2527,7 +2537,7 @@ vscf_message_info_der_serializer_deserialize(
     //
     //  Read: cipherPadding [3] OPTIONAL
     //
-    if (vscf_asn1_reader_left_len(self->asn1_reader)) {
+    if (vscf_asn1_reader_left_len(self->asn1_reader) > message_info_end_left) {
         const size_t cipher_padding_tag_len = vscf_asn1_reader_read_context_tag(self->asn1_reader, 3);
         if (cipher_padding_tag_len != 0) {
             vscf_message_info_der_serializer_deserialize_cipher_padding(self, message_info, &error_ctx);

--- a/tests/foundation/test_recipient_cipher.c
+++ b/tests/foundation/test_recipient_cipher.c
@@ -1880,6 +1880,40 @@ test__kek__crafted_message_info__deserializes(void) {
     vsc_buffer_destroy(&mi);
 }
 
+//  A message info followed by trailing bytes (e.g. the ciphertext stream) must deserialize using
+//  only the VirgilMessageInfo SEQUENCE; a trailing 0xA2 must NOT be misread as the optional
+//  footerInfo [2] field. Regression for the intermittent BAD_MESSAGE_INFO when decrypting a
+//  freshly encrypted KEK message whose ciphertext happened to start with 0xA0..0xA3.
+static void
+test__deserialize__message_info_with_trailing_bytes__ignores_trailing(void) {
+    vsc_data_t kek_id = vsc_data(k_regr_kek_id, sizeof(k_regr_kek_id));
+    vsc_buffer_t *mi = build_kek_message_info(
+            kek_id, vsc_data(k_regr_enc_key, sizeof(k_regr_enc_key)), vsc_data(k_regr_nonce, sizeof(k_regr_nonce)));
+
+    //  Append trailing bytes starting with every optional context tag the parser checks for.
+    const byte trailing[] = {0xA2, 0x10, 0x38, 0x1b, 0xA0, 0xA1, 0xA3, 0x00, 0xFF};
+    vsc_buffer_t *with_tail = vsc_buffer_new_with_capacity(vsc_buffer_len(mi) + sizeof(trailing));
+    vsc_buffer_write_data(with_tail, vsc_buffer_data(mi));
+    vsc_buffer_write_data(with_tail, vsc_data(trailing, sizeof(trailing)));
+
+    vscf_error_t error;
+    vscf_error_reset(&error);
+    vscf_message_info_der_serializer_t *serializer = vscf_message_info_der_serializer_new();
+    vscf_message_info_der_serializer_setup_defaults(serializer);
+    vscf_message_info_t *parsed =
+            vscf_message_info_der_serializer_deserialize(serializer, vsc_buffer_data(with_tail), &error);
+
+    TEST_ASSERT_EQUAL(vscf_status_SUCCESS, vscf_error_status(&error));
+    TEST_ASSERT_NOT_NULL(parsed);
+    const vscf_kek_recipient_info_list_t *list = vscf_message_info_kek_recipient_info_list(parsed);
+    TEST_ASSERT_TRUE(vscf_kek_recipient_info_list_has_item(list));
+
+    vscf_message_info_destroy(&parsed);
+    vscf_message_info_der_serializer_destroy(&serializer);
+    vsc_buffer_destroy(&with_tail);
+    vsc_buffer_destroy(&mi);
+}
+
 //  Empty encryptedKey OCTET STRING must be rejected gracefully, not abort the deserializer.
 static void
 test__kek__empty_encrypted_key__fails_without_abort(void) {
@@ -1980,6 +2014,7 @@ main(void) {
     RUN_TEST(test__decrypt__kek_algorithm_mismatch__fails);
 
     RUN_TEST(test__kek__crafted_message_info__deserializes);
+    RUN_TEST(test__deserialize__message_info_with_trailing_bytes__ignores_trailing);
     RUN_TEST(test__kek__empty_encrypted_key__fails_without_abort);
     RUN_TEST(test__kek__short_encrypted_key__fails_without_abort);
     RUN_TEST(test__kek__misaligned_encrypted_key__fails_without_abort);


### PR DESCRIPTION
Syncs `main` with `develop`. Three changes since the last sync, no library API changes beyond the bugfix:

### Bugfix
- **#206** `fix(foundation)`: the message-info DER deserializer read its optional `VirgilMessageInfo` fields (`customParams [0]`, `cipherKdf [1]`, `footerInfo [2]`, `cipherPadding [3]`) against the end of the whole input buffer instead of the end of the `VirgilMessageInfo` SEQUENCE. When a caller passed a buffer with trailing bytes after the message info (e.g. the full ciphertext stream as an explicit `message_info`), a trailing byte of `0xA0–0xA3` was misread as an optional field and parsing failed with `ERROR_BAD_MESSAGE_INFO` ~5% of the time (data-dependent on the random ciphertext). The common embedded-decryption path was unaffected (it slices exactly the message info). Fix bounds the optional reads to the SEQUENCE; deterministic regression test added. This also resolves the intermittent CI Linux `memcheck` failure (a failed Unity assertion leaked the test's own locals, which the memcheck step reported as "definitely lost").

### CI
- **#203** `fix(ci)`: the release `merge-to-main` job silently never updated `main` (no `actions/checkout`, so `gh` ran outside a git repo and the `|| true` masked the failure). It drifted `main` 64 commits behind across several releases. Now checks out, fails loudly, and merges with `--admin`.

### Docs
- **#204** `docs(readme)`: replace the removed Round5 with ML-KEM-768, add ML-DSA-65 and AES Key Wrap to the algorithm table.

Merging this carries all three to `main`.