### PR TITLE
fix(foundation): message-info deserializer misreads trailing bytes as optional fields

### DIFF
--- a/library/foundation/src/vscf_message_info_der_serializer.c
+++ b/library/foundation/src/vscf_message_info_der_serializer.c
@@ -2474,7 +2474,17 @@ vscf_message_info_der_serializer_deserialize(
     //  Read: VirgilMessageInfo
     //
     vscf_asn1_reader_reset(self->asn1_reader, data);
-    vscf_asn1_reader_read_sequence(self->asn1_reader);
+    const size_t message_info_len = vscf_asn1_reader_read_sequence(self->asn1_reader);
+
+    //  The optional fields below live inside the VirgilMessageInfo SEQUENCE. Reads must stop at the
+    //  end of that SEQUENCE, not at the end of `data` — a caller may pass a buffer that has trailing
+    //  bytes after the message info (e.g. the whole ciphertext stream). `left_len()` counts to the
+    //  end of `data`, so capture the floor value it reaches once the SEQUENCE content is consumed and
+    //  gate every optional read on it. Without this, a trailing byte of 0xA0..0xA3 is misread as an
+    //  optional [0]..[3] field and parsing the following bytes fails intermittently.
+    const size_t left_after_header = vscf_asn1_reader_left_len(self->asn1_reader);
+    const size_t message_info_end_left =
+            (left_after_header > message_info_len) ? (left_after_header - message_info_len) : 0;
 
     //
     //  Read: version
@@ -2496,7 +2506,7 @@ vscf_message_info_der_serializer_deserialize(
     //
     //  Read: customParams [0] OPTIONAL
     //
-    if (vscf_asn1_reader_left_len(self->asn1_reader)) {
+    if (vscf_asn1_reader_left_len(self->asn1_reader) > message_info_end_left) {
         const size_t custom_params_tag_len = vscf_asn1_reader_read_context_tag(self->asn1_reader, 0);
         if (custom_params_tag_len != 0) {
             vscf_message_info_custom_params_t *custom_params = vscf_message_info_custom_params(message_info);
@@ -2507,7 +2517,7 @@ vscf_message_info_der_serializer_deserialize(
     //
     //  Read: cipherKdf [1] OPTIONAL
     //
-    if (vscf_asn1_reader_left_len(self->asn1_reader)) {
+    if (vscf_asn1_reader_left_len(self->asn1_reader) > message_info_end_left) {
         const size_t cipher_kdf_tag_len = vscf_asn1_reader_read_context_tag(self->asn1_reader, 1);
         if (cipher_kdf_tag_len != 0) {
             vscf_message_info_der_serializer_deserialize_cipher_kdf(self, message_info, &error_ctx);
@@ -2517,7 +2527,7 @@ vscf_message_info_der_serializer_deserialize(
     //
     //  Read: footerInfo [2] OPTIONAL
     //
-    if (vscf_asn1_reader_left_len(self->asn1_reader)) {
+    if (vscf_asn1_reader_left_len(self->asn1_reader) > message_info_end_left) {
         const size_t footer_info_tag_len = vscf_asn1_reader_read_context_tag(self->asn1_reader, 2);
         if (footer_info_tag_len != 0) {
             vscf_message_info_der_serializer_deserialize_footer_info(self, message_info, &error_ctx);
@@ -2527,7 +2537,7 @@ vscf_message_info_der_serializer_deserialize(
     //
     //  Read: cipherPadding [3] OPTIONAL
     //
-    if (vscf_asn1_reader_left_len(self->asn1_reader)) {
+    if (vscf_asn1_reader_left_len(self->asn1_reader) > message_info_end_left) {
         const size_t cipher_padding_tag_len = vscf_asn1_reader_read_context_tag(self->asn1_reader, 3);
         if (cipher_padding_tag_len != 0) {
             vscf_message_info_der_serializer_deserialize_cipher_padding(self, message_info, &error_ctx);

--- a/tests/foundation/test_recipient_cipher.c
+++ b/tests/foundation/test_recipient_cipher.c
@@ -1880,6 +1880,40 @@ test__kek__crafted_message_info__deserializes(void) {
     vsc_buffer_destroy(&mi);
 }
 
+//  A message info followed by trailing bytes (e.g. the ciphertext stream) must deserialize using
+//  only the VirgilMessageInfo SEQUENCE; a trailing 0xA2 must NOT be misread as the optional
+//  footerInfo [2] field. Regression for the intermittent BAD_MESSAGE_INFO when decrypting a
+//  freshly encrypted KEK message whose ciphertext happened to start with 0xA0..0xA3.
+static void
+test__deserialize__message_info_with_trailing_bytes__ignores_trailing(void) {
+    vsc_data_t kek_id = vsc_data(k_regr_kek_id, sizeof(k_regr_kek_id));
+    vsc_buffer_t *mi = build_kek_message_info(
+            kek_id, vsc_data(k_regr_enc_key, sizeof(k_regr_enc_key)), vsc_data(k_regr_nonce, sizeof(k_regr_nonce)));
+
+    //  Append trailing bytes starting with every optional context tag the parser checks for.
+    const byte trailing[] = {0xA2, 0x10, 0x38, 0x1b, 0xA0, 0xA1, 0xA3, 0x00, 0xFF};
+    vsc_buffer_t *with_tail = vsc_buffer_new_with_capacity(vsc_buffer_len(mi) + sizeof(trailing));
+    vsc_buffer_write_data(with_tail, vsc_buffer_data(mi));
+    vsc_buffer_write_data(with_tail, vsc_data(trailing, sizeof(trailing)));
+
+    vscf_error_t error;
+    vscf_error_reset(&error);
+    vscf_message_info_der_serializer_t *serializer = vscf_message_info_der_serializer_new();
+    vscf_message_info_der_serializer_setup_defaults(serializer);
+    vscf_message_info_t *parsed =
+            vscf_message_info_der_serializer_deserialize(serializer, vsc_buffer_data(with_tail), &error);
+
+    TEST_ASSERT_EQUAL(vscf_status_SUCCESS, vscf_error_status(&error));
+    TEST_ASSERT_NOT_NULL(parsed);
+    const vscf_kek_recipient_info_list_t *list = vscf_message_info_kek_recipient_info_list(parsed);
+    TEST_ASSERT_TRUE(vscf_kek_recipient_info_list_has_item(list));
+
+    vscf_message_info_destroy(&parsed);
+    vscf_message_info_der_serializer_destroy(&serializer);
+    vsc_buffer_destroy(&with_tail);
+    vsc_buffer_destroy(&mi);
+}
+
 //  Empty encryptedKey OCTET STRING must be rejected gracefully, not abort the deserializer.
 static void
 test__kek__empty_encrypted_key__fails_without_abort(void) {
@@ -1980,6 +2014,7 @@ main(void) {
     RUN_TEST(test__decrypt__kek_algorithm_mismatch__fails);
 
     RUN_TEST(test__kek__crafted_message_info__deserializes);
+    RUN_TEST(test__deserialize__message_info_with_trailing_bytes__ignores_trailing);
     RUN_TEST(test__kek__empty_encrypted_key__fails_without_abort);
     RUN_TEST(test__kek__short_encrypted_key__fails_without_abort);
     RUN_TEST(test__kek__misaligned_encrypted_key__fails_without_abort);


### PR DESCRIPTION
## What you asked
"Check memory leaks, GH Actions Linux build." The Linux build's `Run memcheck` step had started failing.

## What it actually was
**Not a memory leak.** The `Run memcheck` step fails when the test binary exits non-zero, and `test_recipient_cipher` was failing an *assertion* intermittently:

```
test__decrypt__kek_algorithm_mismatch__fails: FAIL: Expected -209 Was -302
test__decrypt__with_aes256_kw_kek_recipient__wrong_kek__auth_fails: FAIL: Expected -311 Was -302
```

Reproduced natively at ~5.5% (22/400 runs) — so it's data-dependent, not Valgrind-specific. Valgrind just happened to be the run that went red.

## Root cause
`vscf_message_info_der_serializer_deserialize` reads the optional `VirgilMessageInfo` fields — `customParams [0]`, `cipherKdf [1]`, `footerInfo [2]`, `cipherPadding [3]` — gated on `vscf_asn1_reader_left_len() > 0`. That counts to the end of the **whole input buffer**, not the end of the `VirgilMessageInfo` SEQUENCE.

When a caller passes a buffer that has trailing bytes after the message info — e.g. the full ciphertext stream as the explicit `message_info` argument of `start_decryption_with_kek` — the first trailing byte is the start of the AES-256-GCM ciphertext, which is random. Whenever it lands on `0xA0..0xA3` it's misread as one of those optional context-tagged fields, and parsing the following random bytes fails with `ERROR_BAD_MESSAGE_INFO`. I captured a failing message; the byte immediately after the SEQUENCE was `0xA2` (→ `footerInfo [2]`).

This is pre-existing (the optional fields predate KEK); the KEK tests surfaced it because they pass the whole stream as `message_info` and exercise many fresh encryptions.

## Fix
Capture the `left_len()` floor that marks the end of the `VirgilMessageInfo` SEQUENCE content and gate every optional-field read on it, so trailing bytes are ignored. A correctly detached message info (no trailing bytes) is unaffected.

## Test
Deterministic regression: a valid message info with a `0xA2` trailing byte must still deserialize and expose its KEK recipient. It returns `-302` without the fix and `SUCCESS` with it. Verified by stash-reverting the fix. Full C suite 76/76; the previously-flaky `test_recipient_cipher` is now 0 failures in 500 runs (was ~5.5%).