### PR TITLE
build(cmake): expose nanopb toolchain to downstream FetchContent consumers

### DIFF
--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -74,9 +74,11 @@ function(_virgil_resolve_protobuf_tools out_protoc out_generator)
         set(_generator "${VIRGIL_PROTOC_GEN_NANOPB}")
     endif()
     if(NOT _generator)
+        # HINTS (virgil's venv) take priority over the system PATH so the pinned
+        # nanopb generator wins over any system-installed one.
         find_program(_generator
                 NAMES protoc-gen-nanopb protoc-gen-nanopb.bat
-                PATHS "$ENV{VIRTUAL_ENV}/bin" "$ENV{VIRTUAL_ENV}/Scripts"
+                HINTS "$ENV{VIRTUAL_ENV}/bin" "$ENV{VIRTUAL_ENV}/Scripts"
                 NO_CMAKE_FIND_ROOT_PATH)
     endif()
     if(NOT _generator)

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -34,11 +34,162 @@
 
 
 #
-# Add generated sources to a target based on the gievn items.
-# Add protobuf sources to a target.
-# given target as an Apple Framework
+# Resolve the protoc compiler and nanopb generator, preferring the values this
+# repo exports (VIRGIL_PROTOC / VIRGIL_PROTOC_GEN_NANOPB and the
+# nanopb::protoc-gen-nanopb target) so downstream consumers do not need a
+# Python virtual environment on PATH. Falls back to $VIRTUAL_ENV and finally the
+# system PATH for backward compatibility with virgil's own build.
 #
-# target_protobuf_sources(<target> [source1...])
+# _virgil_resolve_protobuf_tools(<out_protoc_var> <out_generator_var>)
+#
+function(_virgil_resolve_protobuf_tools out_protoc out_generator)
+
+    #
+    # protoc: exported cache var -> imported 'protoc' target -> system PATH.
+    #
+    set(_protoc "")
+    if(DEFINED VIRGIL_PROTOC AND EXISTS "${VIRGIL_PROTOC}")
+        set(_protoc "${VIRGIL_PROTOC}")
+    elseif(TARGET protoc)
+        get_target_property(_protoc protoc IMPORTED_LOCATION)
+    endif()
+    if(NOT _protoc)
+        find_program(_protoc NAMES protoc NO_CMAKE_FIND_ROOT_PATH)
+    endif()
+    if(NOT _protoc)
+        message(FATAL_ERROR
+                "protoc compiler not found. Provide the 'protoc' target, set VIRGIL_PROTOC, "
+                "or make 'protoc' discoverable on PATH.")
+    endif()
+
+    #
+    # nanopb generator: imported target -> exported cache var -> $VIRTUAL_ENV
+    # (bin/ on *nix, Scripts/ on Windows) -> system PATH.
+    #
+    set(_generator "")
+    if(TARGET nanopb::protoc-gen-nanopb)
+        get_target_property(_generator nanopb::protoc-gen-nanopb IMPORTED_LOCATION)
+    endif()
+    if(NOT _generator AND DEFINED VIRGIL_PROTOC_GEN_NANOPB AND EXISTS "${VIRGIL_PROTOC_GEN_NANOPB}")
+        set(_generator "${VIRGIL_PROTOC_GEN_NANOPB}")
+    endif()
+    if(NOT _generator)
+        find_program(_generator
+                NAMES protoc-gen-nanopb protoc-gen-nanopb.bat
+                PATHS "$ENV{VIRTUAL_ENV}/bin" "$ENV{VIRTUAL_ENV}/Scripts"
+                NO_CMAKE_FIND_ROOT_PATH)
+    endif()
+    if(NOT _generator)
+        message(FATAL_ERROR
+                "nanopb generator 'protoc-gen-nanopb' not found. It is exported by virgil-crypto-c "
+                "as VIRGIL_PROTOC_GEN_NANOPB / the nanopb::protoc-gen-nanopb target; ensure this "
+                "repo was added (FetchContent/add_subdirectory) or set VIRGIL_PROTOC_GEN_NANOPB.")
+    endif()
+
+    set(${out_protoc} "${_protoc}" PARENT_SCOPE)
+    set(${out_generator} "${_generator}" PARENT_SCOPE)
+endfunction()
+
+
+#
+# Generate nanopb C sources from a single .proto file and add them to a target.
+# This is the supported public API for downstream consumers reusing virgil's
+# nanopb toolchain.
+#
+# virgil_nanopb_generate(
+#     TARGET       <target>            # target to add the generated .pb.{c,h} to
+#     PROTO        <file.proto>        # the .proto model (absolute or relative)
+#     [OPTIONS     <file.options>]     # nanopb .options file (auto-detected as
+#                                      #   <name>.options next to PROTO if omitted)
+#     [IMPORT_DIRS <dir>...]           # extra protoc --proto_path entries
+# )
+#
+# The generated <name>.pb.h / <name>.pb.c are written to CMAKE_CURRENT_BINARY_DIR,
+# which is also added to the target's private include dirs. Link the target
+# against nanopb::protobuf-nanopb for the runtime.
+#
+function(virgil_nanopb_generate)
+
+    set(_options "")
+    set(_one_value_args TARGET PROTO OPTIONS)
+    set(_multi_value_args IMPORT_DIRS)
+    cmake_parse_arguments(ARG "${_options}" "${_one_value_args}" "${_multi_value_args}" ${ARGN})
+
+    if(NOT ARG_TARGET)
+        message(FATAL_ERROR "virgil_nanopb_generate: TARGET is required")
+    endif()
+    if(NOT ARG_PROTO)
+        message(FATAL_ERROR "virgil_nanopb_generate: PROTO is required")
+    endif()
+    if(NOT EXISTS "${ARG_PROTO}")
+        message(FATAL_ERROR "virgil_nanopb_generate: PROTO file not found: ${ARG_PROTO}")
+    endif()
+
+    _virgil_resolve_protobuf_tools(_protoc _generator)
+
+    get_filename_component(_proto_dir  "${ARG_PROTO}" DIRECTORY)
+    get_filename_component(_proto_name "${ARG_PROTO}" NAME_WE)
+
+    #
+    # nanopb .options: explicit arg wins, otherwise auto-detect <name>.options
+    # next to the .proto (preserves the historical target_protobuf_sources behaviour).
+    #
+    set(_options_arg "")
+    set(_options_dep "")
+    if(ARG_OPTIONS)
+        if(NOT EXISTS "${ARG_OPTIONS}")
+            message(FATAL_ERROR "virgil_nanopb_generate: OPTIONS file not found: ${ARG_OPTIONS}")
+        endif()
+        set(_options_arg "-f${ARG_OPTIONS}")
+        set(_options_dep "${ARG_OPTIONS}")
+    elseif(EXISTS "${_proto_dir}/${_proto_name}.options")
+        set(_options_arg "-f${_proto_name}.options")
+        set(_options_dep "${_proto_dir}/${_proto_name}.options")
+    endif()
+
+    #
+    # protoc import paths: the .proto directory plus any caller-provided dirs.
+    #
+    set(_proto_path_args "--proto_path=.")
+    foreach(_dir ${ARG_IMPORT_DIRS})
+        list(APPEND _proto_path_args "--proto_path=${_dir}")
+    endforeach()
+
+    set(_out_h "${CMAKE_CURRENT_BINARY_DIR}/${_proto_name}.pb.h")
+    set(_out_c "${CMAKE_CURRENT_BINARY_DIR}/${_proto_name}.pb.c")
+
+    #
+    # Depend on the nanopb runtime target when present so its ExternalProject
+    # (which also produces protoc) is built before generation runs.
+    #
+    set(_runtime_dep "")
+    if(TARGET protobuf-nanopb)
+        set(_runtime_dep protobuf-nanopb)
+    endif()
+
+    add_custom_command(
+            OUTPUT "${_out_h}" "${_out_c}"
+            COMMAND "${_protoc}"
+                "--plugin=protoc-gen-nanopb=${_generator}"
+                "--nanopb_out=${_options_arg}:${CMAKE_CURRENT_BINARY_DIR}"
+                ${_proto_path_args}
+                "${_proto_name}.proto"
+            DEPENDS "${ARG_PROTO}" ${_options_dep} ${_runtime_dep}
+            COMMENT "nanopb: generating ${_proto_name}.pb.{c,h} from ${ARG_PROTO}"
+            WORKING_DIRECTORY "${_proto_dir}"
+            VERBATIM
+            )
+
+    target_sources(${ARG_TARGET} PRIVATE "${_out_h}" "${_out_c}")
+    target_include_directories(${ARG_TARGET} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+endfunction()
+
+
+#
+# Add generated nanopb sources to a target (backward-compatible wrapper around
+# virgil_nanopb_generate). Each source's <name>.options is auto-detected.
+#
+# target_protobuf_sources(<target> [source1.proto ...])
 #
 function(target_protobuf_sources target)
 
@@ -46,76 +197,7 @@ function(target_protobuf_sources target)
         message(FATAL_ERROR "At least one source must be defined")
     endif()
 
-    #
-    # Inspect host system
-    #
-    if(CMAKE_HOST_WIN32)
-        set(HOST_EXECUTABLE_SUFFIX ".exe")
-    endif()
-
-    #
-    # Check runtime
-    #
-    if(TARGET protoc)
-        get_target_property(PROTOC_EXE protoc IMPORTED_LOCATION)
-    endif()
-
-    if(PROTOC_EXE)
-        message(STATUS "Protobuf generator: ${PROTOC_EXE}")
-    else()
-        message(FATAL_ERROR
-                "Protobuf generator 'protoc${HOST_EXECUTABLE_SUFFIX}' is not found as a target "
-                "and not found as an executable within system"
-                )
-    endif()
-
-    #
-    # Check nanopb plug-in.
-    #
-    find_program(PROTOC_GEN_NANOPB  protoc-gen-nanopb PATHS "$ENV{VIRTUAL_ENV}/bin" NO_CMAKE_FIND_ROOT_PATH)
-    if(NOT PROTOC_GEN_NANOPB)
-        message(FATAL_ERROR "Nanopb generator is not found nigher in system path nor in $ENV{VIRTUAL_ENV}/bin/protoc-gen-nanopb")
-    endif()
-
-    #
-    # Create generation command per proto file
-    #
     foreach(proto_file ${ARGN})
-        if(NOT EXISTS "${proto_file}")
-            message(FATAL_ERROR "Protobuf model file is not found: ${proto_file}")
-        endif()
-
-        get_filename_component(proto_file_path "${proto_file}" DIRECTORY)
-        get_filename_component(proto_file_name "${proto_file}" NAME_WE)
-
-        if(EXISTS "${proto_file_path}/${proto_file_name}.options")
-            set(proto_options_file "${proto_file_name}.options")
-            set(proto_options "-f${proto_options_file}")
-        else()
-            set(proto_options_file "")
-            set(proto_options "")
-        endif()
-
-        add_custom_command(
-                OUTPUT
-                    "${CMAKE_CURRENT_BINARY_DIR}/${proto_file_name}.pb.h"
-                    "${CMAKE_CURRENT_BINARY_DIR}/${proto_file_name}.pb.c"
-                COMMAND
-                    "${PROTOC_EXE}"
-                ARGS
-                    --plugin=protoc-gen-nanopb="${PROTOC_GEN_NANOPB}"
-                    --nanopb_out=${proto_options}:"${CMAKE_CURRENT_BINARY_DIR}"
-                    --proto_path=. "${proto_file_name}.proto"
-                DEPENDS
-                    "${proto_file}" "${proto_options_file}" protobuf-nanopb
-                COMMENT "Processing protobuf model: ${proto_file}"
-                WORKING_DIRECTORY "${proto_file_path}"
-                )
-
-        target_sources(${target}
-                PRIVATE
-                    "${CMAKE_CURRENT_BINARY_DIR}/${proto_file_name}.pb.h"
-                    "${CMAKE_CURRENT_BINARY_DIR}/${proto_file_name}.pb.c"
-                )
+        virgil_nanopb_generate(TARGET ${target} PROTO "${proto_file}")
     endforeach()
 endfunction()

--- a/thirdparty/nanopb/CMakeLists.txt
+++ b/thirdparty/nanopb/CMakeLists.txt
@@ -199,11 +199,18 @@ set(VIRGIL_PROTOC "${PROTOC_EXE}"
 
 # venv puts executables in bin/ on *nix and Scripts/ on Windows; also fall back
 # to the ExternalProject-installed generator under the nanopb prefix.
+#
+# HINTS (virgil's own venv) are searched before the system PATH so virgil's
+# pinned nanopb generator wins over any differently-versioned protoc-gen-nanopb
+# a consumer happens to have installed system-wide. The ExternalProject copy is
+# a lower-priority PATHS fallback.
+#
 find_program(VIRGIL_PROTOC_GEN_NANOPB
         NAMES protoc-gen-nanopb protoc-gen-nanopb.bat
-        PATHS
+        HINTS
             "$ENV{VIRTUAL_ENV}/bin"
             "$ENV{VIRTUAL_ENV}/Scripts"
+        PATHS
             "${NANOPB_INSTALL_LOCATION}/bin"
         NO_CMAKE_FIND_ROOT_PATH
         )

--- a/thirdparty/nanopb/CMakeLists.txt
+++ b/thirdparty/nanopb/CMakeLists.txt
@@ -177,6 +177,49 @@ if(NOT TARGET nanopb::protobuf-nanopb)
     add_library(nanopb::protobuf-nanopb ALIAS protobuf-nanopb)
 endif()
 
+# ---------------------------------------------------------------------------
+#   Export the nanopb toolchain for downstream consumers
+# ---------------------------------------------------------------------------
+#
+# Publish the protoc compiler and the nanopb generator so a downstream project
+# (e.g. via FetchContent / add_subdirectory) can generate its own .proto files
+# without having to know about virgil's internal Python venv layout.
+#
+#   VIRGIL_PROTOC              - path to the SHA-pinned protoc built by this repo
+#   VIRGIL_PROTOC_GEN_NANOPB   - path to the nanopb generator plug-in
+#   nanopb::protoc-gen-nanopb  - IMPORTED GLOBAL executable target for the above
+#
+# The generator is virgil's venv copy, which is self-contained (it bundles
+# nanopb + protobuf + grpc_tools and its shebang points at the venv python).
+# virgil's own build populates that venv at configure time, so the copy already
+# exists here for any consumer that added this repo as a subproject.
+#
+set(VIRGIL_PROTOC "${PROTOC_EXE}"
+        CACHE FILEPATH "protoc compiler built by virgil-crypto-c" FORCE)
+
+# venv puts executables in bin/ on *nix and Scripts/ on Windows; also fall back
+# to the ExternalProject-installed generator under the nanopb prefix.
+find_program(VIRGIL_PROTOC_GEN_NANOPB
+        NAMES protoc-gen-nanopb protoc-gen-nanopb.bat
+        PATHS
+            "$ENV{VIRTUAL_ENV}/bin"
+            "$ENV{VIRTUAL_ENV}/Scripts"
+            "${NANOPB_INSTALL_LOCATION}/bin"
+        NO_CMAKE_FIND_ROOT_PATH
+        )
+
+if(VIRGIL_PROTOC_GEN_NANOPB)
+    message(STATUS "VIRGIL_PROTOC_GEN_NANOPB: ${VIRGIL_PROTOC_GEN_NANOPB}")
+    if(NOT TARGET nanopb::protoc-gen-nanopb)
+        add_executable(nanopb::protoc-gen-nanopb IMPORTED GLOBAL)
+        set_target_properties(nanopb::protoc-gen-nanopb PROPERTIES
+                IMPORTED_LOCATION "${VIRGIL_PROTOC_GEN_NANOPB}")
+    endif()
+else()
+    message(STATUS "VIRGIL_PROTOC_GEN_NANOPB: not found at configure time "
+            "(will be resolved lazily by target_protobuf_sources)")
+endif()
+
 
 # ---------------------------------------------------------------------------
 #   Install library


### PR DESCRIPTION
## What & why

A downstream C++ project (`seald-vault`) consumes virgil-crypto-c via CMake **FetchContent** and wants to reuse this repo's nanopb toolchain to generate + link its own `.proto` messages — without a system protobuf or knowledge of virgil's Python venv layout.

Previously `target_protobuf_sources()` located the nanopb generator only via `find_program(... PATHS "$ENV{VIRTUAL_ENV}/bin")`. `$VIRTUAL_ENV` is set for virgil's own build but **not** for a downstream consumer, so consumers couldn't reuse the generator or the function.

## Changes

- **Export the toolchain** (`thirdparty/nanopb/CMakeLists.txt`):
  - `VIRGIL_PROTOC` — cache var, path to the SHA-pinned protoc this repo builds.
  - `VIRGIL_PROTOC_GEN_NANOPB` — cache var, path to the nanopb generator.
  - `nanopb::protoc-gen-nanopb` — IMPORTED GLOBAL executable target.
  - The generator exported is virgil's **self-contained venv copy** (bundles nanopb + protobuf + grpc_tools; shebang → venv python), which virgil's build populates at configure time. Resolved across `bin/` (*nix) and `Scripts/` (Windows).
- **Downstream-safe resolution + public API** (`cmake/protobuf.cmake`):
  - New supported function `virgil_nanopb_generate(TARGET <t> PROTO <f> [OPTIONS <f>] [IMPORT_DIRS ...])`.
  - Tool resolution prefers the exported vars/targets, then falls back to `$VIRTUAL_ENV`, then PATH (virgil's own build unchanged).
  - `target_protobuf_sources()` now delegates to `virgil_nanopb_generate` (auto-detects `<name>.options`; behaviour preserved).

## Acceptance

A separate CMake project doing `FetchContent_MakeAvailable(virgil_crypto)` can, **with no `$VIRTUAL_ENV` set**, generate `foo.pb.{c,h}` from a `foo.proto` (+ `.options`) and link `nanopb::protobuf-nanopb`.

## Verification (local, macOS/clang)

- ✅ Downstream FetchContent consumer (clean env, no `$VIRTUAL_ENV`): generated `foo.pb.{c,h}`, linked `nanopb::protobuf-nanopb`, ran an encode→decode roundtrip.
- ✅ virgil's own C build regenerates its foundation/ratchet/phe pb files through the new path; `ctest` **78/78**.
- ✅ Go wrapper static lib rebuilt via the same path; `go test ./...` passes.
- ⏳ **Windows/MSVC**: not testable locally — relies on this PR's CI (the `Scripts/` path and `VERBATIM` escaping are handled).

## Notes / scope

- BSD-3 license headers preserved on both edited files; no new files; no new required system deps; protoc/nanopb still SHA/tag-pinned.
- **Deferred:** install/export coverage for `find_package` (installed-tree) consumers. The exported generator is a venv-python script whose shebang points into the build tree, so a portable *installed* generator needs additional design (Python-dep bundling). The FetchContent path used by seald-vault works today; this can be a follow-up if an installed-tree consumer appears.
