### PR TITLE
build(cmake): pass nanopb options via --nanopb_opt (fix Windows abs paths)

### DIFF
--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -136,16 +136,22 @@ function(virgil_nanopb_generate)
     # nanopb .options: explicit arg wins, otherwise auto-detect <name>.options
     # next to the .proto (preserves the historical target_protobuf_sources behaviour).
     #
-    set(_options_arg "")
+    # Passed as a plugin option (--nanopb_opt), NOT spliced into --nanopb_out=<opts>:<dir>:
+    # protoc's first-colon split of the combined form collides with a Windows drive-letter
+    # colon in an absolute options path (e.g. -fC:/…/foo.options), so a downstream consumer
+    # that passes an absolute OPTIONS path fails on Windows. Keeping --nanopb_out a bare
+    # directory lets protoc recognise the drive letter, and --nanopb_opt carries -f verbatim.
+    #
+    set(_opt_arg "")
     set(_options_dep "")
     if(ARG_OPTIONS)
         if(NOT EXISTS "${ARG_OPTIONS}")
             message(FATAL_ERROR "virgil_nanopb_generate: OPTIONS file not found: ${ARG_OPTIONS}")
         endif()
-        set(_options_arg "-f${ARG_OPTIONS}")
+        set(_opt_arg "--nanopb_opt=-f${ARG_OPTIONS}")
         set(_options_dep "${ARG_OPTIONS}")
     elseif(EXISTS "${_proto_dir}/${_proto_name}.options")
-        set(_options_arg "-f${_proto_name}.options")
+        set(_opt_arg "--nanopb_opt=-f${_proto_name}.options")
         set(_options_dep "${_proto_dir}/${_proto_name}.options")
     endif()
 
@@ -173,7 +179,8 @@ function(virgil_nanopb_generate)
             OUTPUT "${_out_h}" "${_out_c}"
             COMMAND "${_protoc}"
                 "--plugin=protoc-gen-nanopb=${_generator}"
-                "--nanopb_out=${_options_arg}:${CMAKE_CURRENT_BINARY_DIR}"
+                ${_opt_arg}
+                "--nanopb_out=${CMAKE_CURRENT_BINARY_DIR}"
                 ${_proto_path_args}
                 "${_proto_name}.proto"
             DEPENDS "${ARG_PROTO}" ${_options_dep} ${_runtime_dep}


### PR DESCRIPTION
## Problem
`virgil_nanopb_generate` (added for downstream nanopb codegen) splices the `.options` into `--nanopb_out=<opts>:<outdir>`. protoc splits that on the **first colon**, which collides with a **Windows drive-letter colon** in an *absolute* options path (`-fC:\…\foo.options`). A downstream consumer (FetchContent / `add_subdirectory`) that passes an absolute `OPTIONS` path therefore fails on Windows:

```
Options file not found: C
...\foo.options:C:\...\out\: No such file or directory
```

virgil's own build was unaffected because it uses relative, adjacent `.options` (auto-detected).

## Fix
Pass `-f<options>` as a protoc **plugin option** (`--nanopb_opt`) and keep `--nanopb_out` a **bare output directory** — which protoc parses as a drive-lettered path correctly. Works for both absolute and relative/auto-detected options, on POSIX and Windows.

## Verification
Using the exact `protoc` + `protoc-gen-nanopb` this repo builds, against a real `.proto` + absolute `.options`:

| Invocation | POSIX (macOS) | Windows (MSVC toolchain) |
|---|---|---|
| old `--nanopb_out=-f<opts>:<out>` | ok (no colon in path) | **fails** — `Options file not found: C` |
| new `--nanopb_opt=-f<opts>` + `--nanopb_out=<out>` | ok, generates `.pb.{c,h}` | **ok**, generates `.pb.{c,h}` |

Also confirmed the relative/auto-detected options path (virgil's own build) still generates correctly.