### PR TITLE
build: drop grpcio-tools from requirements.txt

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -173,15 +173,15 @@ jobs:
       # one actions/setup-python installed. The root CMakeLists runs
       # `pip3 install -r requirements.txt` at configure time and ignores the
       # result, so a failure there surfaces later as a missing nanopb
-      # generator. grpcio-tools has no mingw aarch64 wheel and would abort the
-      # whole transaction; the Go target only needs the nanopb generator, so
-      # install just that and let CMake find it on PATH.
+      # generator. Its venv is also unreachable on Windows -- CMakeLists joins
+      # the venv path onto PATH with a POSIX ':' separator, which the native
+      # cmake.exe cannot parse -- so the venv is built and activated here.
       - name: Python codegen deps (Windows ARM64)
         if: matrix.msys2
         shell: msys2 {0}
         run: |
           python3 -m venv /c/venv
-          /c/venv/bin/pip3 install -q -U protobuf nanopb
+          /c/venv/bin/pip3 install -q -U -r requirements.txt
           test -x /c/venv/bin/protoc-gen-nanopb
           # Hand the venv to the later steps through GitHub's own mechanism.
           # The build needs it *active*, not just discoverable: nanopb's

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 protobuf>=5.28.3
-grpcio-tools>=1.32.0
 nanopb>=0.4.9

--- a/thirdparty/nanopb/CMakeLists.txt
+++ b/thirdparty/nanopb/CMakeLists.txt
@@ -190,7 +190,8 @@ endif()
 #   nanopb::protoc-gen-nanopb  - IMPORTED GLOBAL executable target for the above
 #
 # The generator is virgil's venv copy, which is self-contained (it bundles
-# nanopb + protobuf + grpc_tools and its shebang points at the venv python).
+# nanopb + protobuf and its shebang points at the venv python). protoc itself
+# is the SHA-pinned binary downloaded above, not a Python-provided one.
 # virgil's own build populates that venv at configure time, so the copy already
 # exists here for any consumer that added this repo as a subproject.
 #


### PR DESCRIPTION
## Summary

Removes `grpcio-tools` from `requirements.txt`. Nothing in the CMake build uses it.

Evidence:

- **protoc does not come from Python here.** `thirdparty/nanopb/CMakeLists.txt:50-62` downloads a SHA-256-pinned protoc v28.3 per host platform and exports it as `VIRGIL_PROTOC`. That is stricter than a pip-resolved version, and it covers both reasons `grpcio-tools` is normally used with nanopb (supplying protoc, and avoiding version mismatch).
- **nanopb treats it as optional.** `nanopb_generator.py` imports it inside a bare `try: import grpc_tools.protoc / except: pass` — a packaging convenience, not a dependency.
- **No other reference.** The only remaining mentions were two comments, now corrected. `build-java.yml:104` installs `protobuf grpcio-tools` itself, so the Java codegen path is unaffected.

## Why it mattered

On `windows_arm64` there is no mingw aarch64 wheel for `grpcio-tools`, so pip compiled gRPC, abseil and protobuf C++ **from source on every run** — a from-source build that could break on any toolchain change, for a dependency the build never uses. The Python dependency step is now 8s and deterministic.

**Measured effect on job time is small.** `Go (windows_arm64)` went 14m13s -> 12m41s (~1.5 min). An earlier revision of this description claimed the gRPC compile was "most of" that job's runtime; that was wrong. Per-step timings show the dominant cost is the MSYS2 pacman transaction (316s), with `Build native libraries` at only 60s — so the gRPC build could never have accounted for the gap. Treat this as a correctness and robustness change, not a performance one.

## Testing

Verified locally with a deleted build directory, so CMake created a fresh venv and installed the reduced requirements — this genuinely exercises the new list rather than a warm cache:

- `cmake -Bbuild -S.` + `cmake --build build` — clean configure and build
- `ctest` — 78/78 passed
- `python3 -m pytest tools/codegen/ -q` — 427 passed
- `go build ./...` / `go test ./...` — pass
- `actionlint` — clean

The point of this PR is to confirm the same across every CI target, particularly the wrapper jobs (Python, PHP, WASM, Java) that were not exercised locally.

## Note

Unrelated to this change: release `0.23.1` failed at `Build Apple xcframeworks` with `Empty reply from server` while fetching protoc from GitHub — a transient network failure. It fail-closed correctly (no tags, no binary commit, nothing published) and is re-runnable as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

